### PR TITLE
page content from metadata

### DIFF
--- a/_indicators/1-1-1.md
+++ b/_indicators/1-1-1.md
@@ -4,8 +4,4 @@ layout: indicator
 permalink: /1-1-1/
 ---
 
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator.
-
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/1-2-1.md
+++ b/_indicators/1-2-1.md
@@ -3,8 +3,5 @@ indicator: 1.2.1
 layout: indicator
 permalink: /1-2-1/
 ---
-"Percentage of the population living in households at risk of poverty" data from EU-Statistics on Income and Living Conditions (EU-SILC) is being used for international comparability. For the main UK data series on low income households see the [Households below average income (HBAI) statistics](https://www.gov.uk/government/collections/households-below-average-income-hbai--2).
-
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/1-2-2.md
+++ b/_indicators/1-2-2.md
@@ -3,9 +3,5 @@ indicator: 1.2.2
 layout: indicator
 permalink: /1-2-2/
 ---
-"Percentage of the population living in households persistently at risk of poverty" data from EU-Statistics on Income and Living Conditions (EU-SILC) is being used for international comparability. For the main UK data series on persistent low income households see the [Income Dynamics](https://www.gov.uk/government/statistics/income-dynamics-experimental) experimental statistics.
-
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>.
-
 
 

--- a/_indicators/1-3-1.md
+++ b/_indicators/1-3-1.md
@@ -3,8 +3,5 @@ indicator: 1.3.1
 layout: indicator
 permalink: /1-3-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/1-4-1.md
+++ b/_indicators/1-4-1.md
@@ -3,8 +3,5 @@ indicator: 1.4.1
 layout: indicator
 permalink: /1-4-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/1-4-2.md
+++ b/_indicators/1-4-2.md
@@ -3,8 +3,5 @@ indicator: 1.4.2
 layout: indicator
 permalink: /1-4-2/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and has not been identified in collaboration with topic experts. We will work to identify or develop UK data to meet the global indicator specification.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/1-5-1.md
+++ b/_indicators/1-5-1.md
@@ -3,8 +3,5 @@ indicator: 1.5.1
 layout: indicator
 permalink: /1-5-1/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and has not been identified in collaboration with topic experts. We will work to identify or develop UK data to meet the global indicator specification.
 
-Data availability within the UK is limited to England and Wales for this indicator.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+

--- a/_indicators/1-5-2.md
+++ b/_indicators/1-5-2.md
@@ -3,8 +3,5 @@ indicator: 1.5.2
 layout: indicator
 permalink: /1-5-2/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/1-5-3.md
+++ b/_indicators/1-5-3.md
@@ -3,8 +3,5 @@ indicator: 1.5.3
 layout: indicator
 permalink: /1-5-3/
 ---
-**Non-statistical indicator**
 
-We have identified the following policies relevant to this indicator: [PreventionWeb: United Kingdom](https://www.preventionweb.net/english/countries/europe/gbr/).
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions please contact us at <SustainableDevelopment@ons.gov.uk>.

--- a/_indicators/1-5-4.md
+++ b/_indicators/1-5-4.md
@@ -3,8 +3,5 @@ indicator: 1.5.4
 layout: indicator
 permalink: /1-5-4/
 ---
-**Statistics in progress**               
 
-A potential data source has been identified. Further work is needed for this indicator.
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/1-a-1.md
+++ b/_indicators/1-a-1.md
@@ -3,8 +3,5 @@ indicator: 1.a.1
 layout: indicator
 permalink: /1-a-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/1-a-2.md
+++ b/_indicators/1-a-2.md
@@ -3,8 +3,5 @@ indicator: 1.a.2
 layout: indicator
 permalink: /1-a-2/
 ---
-Data follows the UN specification for this indicator; however it has not been identified in collaboration with topic experts. As with all indicators, this will be reviewed.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/1-a-3.md
+++ b/_indicators/1-a-3.md
@@ -3,8 +3,5 @@ indicator: 1.a.3
 layout: indicator
 permalink: /1-a-3/
 ---
-**Statistics in progress**               
 
-A potential data source has been identified. Further work is needed for this indicator.
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/1-b-1.md
+++ b/_indicators/1-b-1.md
@@ -3,8 +3,5 @@ indicator: 1.b.1
 layout: indicator
 permalink: /1-b-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/10-1-1.md
+++ b/_indicators/10-1-1.md
@@ -3,8 +3,5 @@ indicator: 10.1.1
 layout: indicator
 permalink: /10-1-1/
 ---
-**Statistics in progress**               
 
-A potential data source has been identified. Further work is needed for this indicator.
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/10-2-1.md
+++ b/_indicators/10-2-1.md
@@ -3,8 +3,5 @@ indicator: 10.2.1
 layout: indicator
 permalink: /10-2-1/
 ---
-Data follows the UN specification for this indicator and has been indentified in collaboration with topic experts.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/10-3-1.md
+++ b/_indicators/10-3-1.md
@@ -3,8 +3,5 @@ indicator: 10.3.1
 layout: indicator
 permalink: /10-3-1/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and has not been identified in collaboration with topic experts. We will work to identify or develop UK data to meet the global indicator specification.
-  
-Data availability within the UK is limited to England and Wales for this indicator.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+
+

--- a/_indicators/10-4-1.md
+++ b/_indicators/10-4-1.md
@@ -3,6 +3,5 @@ indicator: 10.4.1
 layout: indicator
 permalink: /10-4-1/
 ---
-Data follows the UN specification for this indicator and has been indentified in collaboration with topic experts.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+
+

--- a/_indicators/10-5-1.md
+++ b/_indicators/10-5-1.md
@@ -3,8 +3,5 @@ indicator: 10.5.1
 layout: indicator
 permalink: /10-5-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/10-6-1.md
+++ b/_indicators/10-6-1.md
@@ -3,8 +3,5 @@ indicator: 10.6.1
 layout: indicator
 permalink: /10-6-1/
 ---
-**Using UN data**
 
-Data for this indicator has been sourced from the UN SDG database. As with all indicators, this will be reviewed.
 
-The Sustainable Development Goals is a collaborative project. If you have any feedback or suggestions for data please contact us at SustainableDevelopment@ons.gov.uk.

--- a/_indicators/10-7-1.md
+++ b/_indicators/10-7-1.md
@@ -3,8 +3,5 @@ indicator: 10.7.1
 layout: indicator
 permalink: /10-7-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/10-7-2.md
+++ b/_indicators/10-7-2.md
@@ -3,8 +3,5 @@ indicator: 10.7.2
 layout: indicator
 permalink: /10-7-2/
 ---
-**Statistics in progress**               
 
-This is not a statistical indicator. However, we will collaborate with the policy lead in the UK so that we are able to link to the relevant legislative framework.
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/10-a-1.md
+++ b/_indicators/10-a-1.md
@@ -3,8 +3,5 @@ indicator: 10.a.1
 layout: indicator
 permalink: /10-a-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/10-b-1.md
+++ b/_indicators/10-b-1.md
@@ -3,8 +3,5 @@ indicator: 10.b.1
 layout: indicator
 permalink: /10-b-1/
 ---
-Data follows the UN specification for this indicator; however it has not been identified in collaboration with topic experts. As with all indicators, this will be reviewed.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/10-c-1.md
+++ b/_indicators/10-c-1.md
@@ -3,8 +3,5 @@ indicator: 10.c.1
 layout: indicator
 permalink: /10-c-1/
 ---
-Data follows the UN specification for this indicator and has been indentified in collaboration with topic experts.
 
-The World Bank, Remittance Prices Worldwide, available at http://remittanceprices.worldbank.org
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/11-1-1.md
+++ b/_indicators/11-1-1.md
@@ -3,8 +3,5 @@ indicator: 11.1.1
 layout: indicator
 permalink: /11-1-1/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and has not been identified in collaboration with topic experts. We will work to identify or develop UK data to meet the global indicator specification.
 
-Data availability within the UK is limited to England for this indicator.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+

--- a/_indicators/11-2-1.md
+++ b/_indicators/11-2-1.md
@@ -3,8 +3,5 @@ indicator: 11.2.1
 layout: indicator
 permalink: /11-2-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/11-3-1.md
+++ b/_indicators/11-3-1.md
@@ -3,8 +3,5 @@ indicator: 11.3.1
 layout: indicator
 permalink: /11-3-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/11-3-2.md
+++ b/_indicators/11-3-2.md
@@ -3,8 +3,5 @@ indicator: 11.3.2
 layout: indicator
 permalink: /11-3-2/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/11-4-1.md
+++ b/_indicators/11-4-1.md
@@ -3,8 +3,5 @@ indicator: 11.4.1
 layout: indicator
 permalink: /11-4-1/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and has not been identified in collaboration with topic experts. We will work to identify or develop UK data to meet the global indicator specification.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/11-5-1.md
+++ b/_indicators/11-5-1.md
@@ -3,8 +3,5 @@ indicator: 11.5.1
 layout: indicator
 permalink: /11-5-1/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and has not been identified in collaboration with topic experts. We will work to identify or develop UK data to meet the global indicator specification.
 
-Data availability within the UK is limited to England and Wales for this indicator.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+

--- a/_indicators/11-5-2.md
+++ b/_indicators/11-5-2.md
@@ -3,8 +3,5 @@ indicator: 11.5.2
 layout: indicator
 permalink: /11-5-2/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/11-6-1.md
+++ b/_indicators/11-6-1.md
@@ -3,8 +3,5 @@ indicator: 11.6.1
 layout: indicator
 permalink: /11-6-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/11-6-2.md
+++ b/_indicators/11-6-2.md
@@ -3,6 +3,5 @@ indicator: 11.6.2
 layout: indicator
 permalink: /11-6-2/
 ---
-Data follows the UN specification for this indicator and has been indentified in collaboration with topic experts. Data availability within the UK is limited to United Kingdom for this indicator.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+
+

--- a/_indicators/11-7-1.md
+++ b/_indicators/11-7-1.md
@@ -3,8 +3,5 @@ indicator: 11.7.1
 layout: indicator
 permalink: /11-7-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/11-7-2.md
+++ b/_indicators/11-7-2.md
@@ -3,8 +3,5 @@ indicator: 11.7.2
 layout: indicator
 permalink: /11-7-2/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and has been identified in collaboration with topic experts. We will work to develop UK data to meet the global indicator specification.
-  
-Data availability within the UK is limited to England and Wales for this indicator.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+
+

--- a/_indicators/11-a-1.md
+++ b/_indicators/11-a-1.md
@@ -3,8 +3,5 @@ indicator: 11.a.1
 layout: indicator
 permalink: /11-a-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/11-b-1.md
+++ b/_indicators/11-b-1.md
@@ -3,8 +3,5 @@ indicator: 11.b.1
 layout: indicator
 permalink: /11-b-1/
 ---
-**Non-statistical indicator**
 
-We have identified the following policies relevant to this indicator: [PreventionWeb: United Kingdom](https://www.preventionweb.net/english/countries/europe/gbr/).
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions please contact us at <SustainableDevelopment@ons.gov.uk>.

--- a/_indicators/11-b-2.md
+++ b/_indicators/11-b-2.md
@@ -3,8 +3,5 @@ indicator: 11.b.2
 layout: indicator
 permalink: /11-b-2/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/11-c-1.md
+++ b/_indicators/11-c-1.md
@@ -3,8 +3,5 @@ indicator: 11.c.1
 layout: indicator
 permalink: /11-c-1/
 ---
-Data follows the UN specification for this indicator; however it has not been identified in collaboration with topic experts. As with all indicators, this will be reviewed.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/12-1-1.md
+++ b/_indicators/12-1-1.md
@@ -3,8 +3,5 @@ indicator: 12.1.1
 layout: indicator
 permalink: /12-1-1/
 ---
-**Non-statistical indicator**
 
-We have identified the following policies relevant to this indicator: [Waste legislation and regulations](https://www.gov.uk/guidance/waste-legislation-and-regulations).
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions please contact us at <SustainableDevelopment@ons.gov.uk>.

--- a/_indicators/12-2-1.md
+++ b/_indicators/12-2-1.md
@@ -3,8 +3,5 @@ indicator: 12.2.1
 layout: indicator
 permalink: /12-2-1/
 ---
-Data follows the UN specification for this indicator and has been indentified in collaboration with topic experts.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/12-2-2.md
+++ b/_indicators/12-2-2.md
@@ -3,8 +3,5 @@ indicator: 12.2.2
 layout: indicator
 permalink: /12-2-2/
 ---
-Data follows the UN specification for this indicator and has been indentified in collaboration with topic experts.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/12-3-1.md
+++ b/_indicators/12-3-1.md
@@ -3,8 +3,5 @@ indicator: 12.3.1
 layout: indicator
 permalink: /12-3-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/12-4-1.md
+++ b/_indicators/12-4-1.md
@@ -3,8 +3,5 @@ indicator: 12.4.1
 layout: indicator
 permalink: /12-4-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/12-4-2.md
+++ b/_indicators/12-4-2.md
@@ -3,8 +3,5 @@ indicator: 12.4.2
 layout: indicator
 permalink: /12-4-2/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/12-5-1.md
+++ b/_indicators/12-5-1.md
@@ -3,8 +3,5 @@ indicator: 12.5.1
 layout: indicator
 permalink: /12-5-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/12-6-1.md
+++ b/_indicators/12-6-1.md
@@ -3,8 +3,5 @@ indicator: 12.6.1
 layout: indicator
 permalink: /12-6-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/12-7-1.md
+++ b/_indicators/12-7-1.md
@@ -3,8 +3,5 @@ indicator: 12.7.1
 layout: indicator
 permalink: /12-7-1/
 ---
-**Non-statistical indicator**
 
-We have identified the following policies relevant to this indicator: [Sustainable procurement: the Government Buying Standards (GBS)](https://www.gov.uk/government/collections/sustainable-procurement-the-government-buying-standards-gbs).
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions please contact us at <SustainableDevelopment@ons.gov.uk>.

--- a/_indicators/12-8-1.md
+++ b/_indicators/12-8-1.md
@@ -3,26 +3,5 @@ indicator: 12.8.1
 layout: indicator
 permalink: /12-8-1/
 ---
-**Non-statistical indicator**
 
-Education in the UK is devolved, and so there is some variance in the approach to Education for Sustainable Development (ESD). We have therefore identified relevant policy/legislation by country, as well as the official curriculum and some supporting case studies.
 
-*England*
-
-[National Curriculum](https://www.gov.uk/government/collections/national-curriculum)
-
-*Northern Ireland*
-
-[Overview of the Northern Ireland Curriculum](http://ccea.org.uk/curriculum/overview)
-
-*Scotland*
-
-[Curriculum for Excellence](http://www.gov.scot/resource/doc/226155/0061245.pdf) and [Learning for Sustainability (DOC 33 KB)](http://www.gov.scot/resource/0041/00416172.docx)
-
-*Wales*
-
-[Curriculum](http://learning.gov.wales/resources/improvementareas/curriculum/?lang=en), [Well-being of Future Generations (Wales) Act 2015](http://www.legislation.gov.uk/anaw/2015/2/contents/enacted) (see Goal 4 in particular) and [Education for Sustainable Development and Global Citizenship](http://learning.gov.wales/resources/browse-all/education-for-sustainable-development-and-global-citizenship/?lang=en)
-
-A support document showing relevant ESD case studies can be found in [‘Good practice in Education for Sustainable Development (ESD) in the UK: Case Studies’ (PDF 165 KB)](https://www.unesco.org.uk/wp-content/uploads/2017/04/UKNC-Case-Study-1-FINAL.pdf).
-
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions please contact us at <SustainableDevelopment@ons.gov.uk>.

--- a/_indicators/12-a-1.md
+++ b/_indicators/12-a-1.md
@@ -3,8 +3,5 @@ indicator: 12.a.1
 layout: indicator
 permalink: /12-a-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/12-b-1.md
+++ b/_indicators/12-b-1.md
@@ -3,8 +3,5 @@ indicator: 12.b.1
 layout: indicator
 permalink: /12-b-1/
 ---
-**Statistics in progress**               
 
-This is not a statistical indicator. However, we will collaborate with the policy lead in the UK so that we are able to link to the relevant legislative framework.
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/12-c-1.md
+++ b/_indicators/12-c-1.md
@@ -3,8 +3,5 @@ indicator: 12.c.1
 layout: indicator
 permalink: /12-c-1/
 ---
-**Exploring data sources**          
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/13-1-1.md
+++ b/_indicators/13-1-1.md
@@ -3,8 +3,5 @@ indicator: 13.1.1
 layout: indicator
 permalink: /13-1-1/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and has not been identified in collaboration with topic experts. We will work to identify or develop UK data to meet the global indicator specification.
 
-Data availability within the UK is limited to England and Wales for this indicator.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+

--- a/_indicators/13-1-2.md
+++ b/_indicators/13-1-2.md
@@ -3,8 +3,5 @@ indicator: 13.1.2
 layout: indicator
 permalink: /13-1-2/
 ---
-**Non-statistical indicator**
 
-We have identified the following policies relevant to this indicator: [PreventionWeb: United Kingdom](https://www.preventionweb.net/english/countries/europe/gbr/).
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions please contact us at <SustainableDevelopment@ons.gov.uk>.

--- a/_indicators/13-1-3.md
+++ b/_indicators/13-1-3.md
@@ -3,9 +3,5 @@ indicator: 13.1.3
 layout: indicator
 permalink: /13-1-3/
 ---
-**Exploring data sources**
 
 
-We have not explored suitable data sources for this indicator. 
-
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/13-2-1.md
+++ b/_indicators/13-2-1.md
@@ -3,8 +3,5 @@ indicator: 13.2.1
 layout: indicator
 permalink: /13-2-1/
 ---
-**Non-statistical indicator**
 
-We have identified the following policies relevant to this indicator: [Climate Change Act](https://www.legislation.gov.uk/ukpga/2008/27/contents) and [UK Climate Change Risk Assessment 2017](https://www.gov.uk/government/publications/uk-climate-change-risk-assessment-2017).
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions please contact us at <SustainableDevelopment@ons.gov.uk>.

--- a/_indicators/13-3-1.md
+++ b/_indicators/13-3-1.md
@@ -3,26 +3,5 @@ indicator: 13.3.1
 layout: indicator
 permalink: /13-3-1/
 ---
-**Non-statistical indicator**
 
-Education in the UK is devolved, and so there is some variance in the approach to Education for Sustainable Development (ESD). We have therefore identified relevant policy/legislation by country, as well as the official curriculum and some supporting case studies.
 
-*England*
-
-[National Curriculum](https://www.gov.uk/government/collections/national-curriculum)
-
-*Northern Ireland*
-
-[Overview of the Northern Ireland Curriculum](http://ccea.org.uk/curriculum/overview)
-
-*Scotland*
-
-[Curriculum for Excellence](http://www.gov.scot/resource/doc/226155/0061245.pdf) and [Learning for Sustainability (DOC 33 KB)](http://www.gov.scot/resource/0041/00416172.docx)
-
-*Wales*
-
-[Curriculum](http://learning.gov.wales/resources/improvementareas/curriculum/?lang=en), [Well-being of Future Generations (Wales) Act 2015](http://www.legislation.gov.uk/anaw/2015/2/contents/enacted) (see Goal 4 in particular) and [Education for Sustainable Development and Global Citizenship](http://learning.gov.wales/resources/browse-all/education-for-sustainable-development-and-global-citizenship/?lang=en)
-
-A support document showing relevant ESD case studies can be found in [‘Good practice in Education for Sustainable Development (ESD) in the UK: Case Studies’ (PDF 165 KB)](https://www.unesco.org.uk/wp-content/uploads/2017/04/UKNC-Case-Study-1-FINAL.pdf).
-
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions please contact us at <SustainableDevelopment@ons.gov.uk>.

--- a/_indicators/13-3-2.md
+++ b/_indicators/13-3-2.md
@@ -3,8 +3,5 @@ indicator: 13.3.2
 layout: indicator
 permalink: /13-3-2/
 ---
-**Non-statistical indicator**
 
-We have identified the following policies relevant to this indicator: [Climate Change Act](https://www.legislation.gov.uk/ukpga/2008/27/contents) and [UK Climate Change Risk Assessment 2017](https://www.gov.uk/government/publications/uk-climate-change-risk-assessment-2017).
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions please contact us at <SustainableDevelopment@ons.gov.uk>.

--- a/_indicators/13-a-1.md
+++ b/_indicators/13-a-1.md
@@ -3,8 +3,5 @@ indicator: 13.a.1
 layout: indicator
 permalink: /13-a-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/13-b-1.md
+++ b/_indicators/13-b-1.md
@@ -3,8 +3,5 @@ indicator: 13.b.1
 layout: indicator
 permalink: /13-b-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/14-1-1.md
+++ b/_indicators/14-1-1.md
@@ -3,8 +3,5 @@ indicator: 14.1.1
 layout: indicator
 permalink: /14-1-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/14-2-1.md
+++ b/_indicators/14-2-1.md
@@ -3,8 +3,5 @@ indicator: 14.2.1
 layout: indicator
 permalink: /14-2-1/
 ---
-**Expert Led**
 
-This indicator meets the UN specification for this indicator and been indentified in collaboration with the topic expert.
 
-The Sustainable Development Goals is a collaborative project. If you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>.

--- a/_indicators/14-3-1.md
+++ b/_indicators/14-3-1.md
@@ -3,8 +3,5 @@ indicator: 14.3.1
 layout: indicator
 permalink: /14-3-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/14-4-1.md
+++ b/_indicators/14-4-1.md
@@ -3,8 +3,5 @@ indicator: 14.4.1
 layout: indicator
 permalink: /14-4-1/
 ---
-Data follows the UN specification for this indicator; however it has not been identified in collaboration with topic experts. As with all indicators, this will be reviewed.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/14-5-1.md
+++ b/_indicators/14-5-1.md
@@ -3,6 +3,5 @@ indicator: 14.5.1
 layout: indicator
 permalink: /14-5-1/
 ---
-Data follows the UN specification for this indicator; however it has not been identified in collaboration with topic experts. As with all indicators, this will be reviewed.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+
+

--- a/_indicators/14-6-1.md
+++ b/_indicators/14-6-1.md
@@ -3,8 +3,5 @@ indicator: 14.6.1
 layout: indicator
 permalink: /14-6-1/
 ---
-**Statistics in progress**               
 
-This is not a statistical indicator. However, we will collaborate with the policy lead in the UK so that we are able to link to the relevant legislative framework.
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/14-7-1.md
+++ b/_indicators/14-7-1.md
@@ -3,8 +3,5 @@ indicator: 14.7.1
 layout: indicator
 permalink: /14-7-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/14-a-1.md
+++ b/_indicators/14-a-1.md
@@ -3,8 +3,5 @@ indicator: 14.a.1
 layout: indicator
 permalink: /14-a-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/14-b-1.md
+++ b/_indicators/14-b-1.md
@@ -3,8 +3,5 @@ indicator: 14.b.1
 layout: indicator
 permalink: /14-b-1/
 ---
-**Statistics in progress**          
 
-This is not a statistical indicator. However, we will collaborate with the policy lead in the UK so that we are able to link to the relevant legislative framework.
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/14-c-1.md
+++ b/_indicators/14-c-1.md
@@ -3,8 +3,5 @@ indicator: 14.c.1
 layout: indicator
 permalink: /14-c-1/
 ---
-**Statistics in progress**               
 
-This is not a statistical indicator. However, we will collaborate with the policy lead in the UK so that we are able to link to the relevant legislative framework.
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/15-1-1.md
+++ b/_indicators/15-1-1.md
@@ -3,8 +3,5 @@ indicator: 15.1.1
 layout: indicator
 permalink: /15-1-1/
 ---
-Data follows the UN specification for this indicator; however it has not been identified in collaboration with topic experts. As with all indicators, this will be reviewed.
-  
-Data availability within the UK is limited to United Kingdom for this indicator.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+
+

--- a/_indicators/15-1-2.md
+++ b/_indicators/15-1-2.md
@@ -3,8 +3,5 @@ indicator: 15.1.2
 layout: indicator
 permalink: /15-1-2/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/15-2-1.md
+++ b/_indicators/15-2-1.md
@@ -3,8 +3,5 @@ indicator: 15.2.1
 layout: indicator
 permalink: /15-2-1/
 ---
-Data follows the UN specification for this indicator; however it has not been identified in collaboration with topic experts. As with all indicators, this will be reviewed.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/15-3-1.md
+++ b/_indicators/15-3-1.md
@@ -3,8 +3,5 @@ indicator: 15.3.1
 layout: indicator
 permalink: /15-3-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/15-4-1.md
+++ b/_indicators/15-4-1.md
@@ -3,8 +3,5 @@ indicator: 15.4.1
 layout: indicator
 permalink: /15-4-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/15-4-2.md
+++ b/_indicators/15-4-2.md
@@ -3,8 +3,5 @@ indicator: 15.4.2
 layout: indicator
 permalink: /15-4-2/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/15-5-1.md
+++ b/_indicators/15-5-1.md
@@ -3,8 +3,5 @@ indicator: 15.5.1
 layout: indicator
 permalink: /15-5-1/
 ---
-Data follows the UN specification for this indicator; however it has not been identified in collaboration with topic experts. As with all indicators, this will be reviewed.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/15-6-1.md
+++ b/_indicators/15-6-1.md
@@ -3,8 +3,5 @@ indicator: 15.6.1
 layout: indicator
 permalink: /15-6-1/
 ---
-**Non-statistical indicator**
 
-We have identified the following policies relevant to this indicator: [The Nagoya Protocol on access and benefit sharing (ABS)](https://www.gov.uk/guidance/abs).
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions please contact us at <SustainableDevelopment@ons.gov.uk>.

--- a/_indicators/15-7-1.md
+++ b/_indicators/15-7-1.md
@@ -3,8 +3,5 @@ indicator: 15.7.1
 layout: indicator
 permalink: /15-7-1/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and has not been identified in collaboration with topic experts. We will work to identify or develop UK data to meet the global indicator specification.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/15-8-1.md
+++ b/_indicators/15-8-1.md
@@ -3,8 +3,5 @@ indicator: 15.8.1
 layout: indicator
 permalink: /15-8-1/
 ---
-**Non-statistical indicator**
 
-We have identified the following policies relevant to this indicator: [Wildlife and Countryside Act 1981](http://www.legislation.gov.uk/ukpga/1981/69).
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions please contact us at <SustainableDevelopment@ons.gov.uk>.

--- a/_indicators/15-9-1.md
+++ b/_indicators/15-9-1.md
@@ -3,8 +3,5 @@ indicator: 15.9.1
 layout: indicator
 permalink: /15-9-1/
 ---
-**Statistics in progress**               
 
-This is not a statistical indicator. However, we will collaborate with the policy lead in the UK so that we are able to link to the relevant legislative framework.
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/15-a-1.md
+++ b/_indicators/15-a-1.md
@@ -3,8 +3,5 @@ indicator: 15.a.1
 layout: indicator
 permalink: /15-a-1/
 ---
-Data follows the UN specification for this indicator; however it has not been identified in collaboration with topic experts. As with all indicators, this will be reviewed.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/15-b-1.md
+++ b/_indicators/15-b-1.md
@@ -3,8 +3,5 @@ indicator: 15.b.1
 layout: indicator
 permalink: /15-b-1/
 ---
-Data follows the UN specification for this indicator; however it has not been identified in collaboration with topic experts. As with all indicators, this will be reviewed.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/15-c-1.md
+++ b/_indicators/15-c-1.md
@@ -3,8 +3,5 @@ indicator: 15.c.1
 layout: indicator
 permalink: /15-c-1/
 ---
-Data follows the UN specification for this indicator; however it has not been identified in collaboration with topic experts. As with all indicators, this will be reviewed.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/16-1-1.md
+++ b/_indicators/16-1-1.md
@@ -3,8 +3,5 @@ indicator: 16.1.1
 layout: indicator
 permalink: /16-1-1/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and has been identified in collaboration with topic experts. We will work to develop UK data to meet the global indicator specification.
-  
-Data availability within the UK is limited to England and Wales for this indicator.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+
+

--- a/_indicators/16-1-2.md
+++ b/_indicators/16-1-2.md
@@ -3,8 +3,5 @@ indicator: 16.1.2
 layout: indicator
 permalink: /16-1-2/
 ---
-Data follows the UN specification for this indicator; however it has not been identified in collaboration with topic experts. As with all indicators, this will be reviewed.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/16-1-3.md
+++ b/_indicators/16-1-3.md
@@ -3,8 +3,5 @@ indicator: 16.1.3
 layout: indicator
 permalink: /16-1-3/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and has not been identified in collaboration with topic experts. We will work to identify or develop UK data to meet the global indicator specification.
 
-Data availability within the UK is limited to England and Wales for this indicator.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+

--- a/_indicators/16-1-4.md
+++ b/_indicators/16-1-4.md
@@ -3,8 +3,5 @@ indicator: 16.1.4
 layout: indicator
 permalink: /16-1-4/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and has been identified in collaboration with topic experts. We will work to develop UK data to meet the global indicator specification.
-  
-Data availability within the UK is limited to England and Wales for this indicator.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+
+

--- a/_indicators/16-10-1.md
+++ b/_indicators/16-10-1.md
@@ -3,8 +3,5 @@ indicator: 16.10.1
 layout: indicator
 permalink: /16-10-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/16-10-2.md
+++ b/_indicators/16-10-2.md
@@ -3,8 +3,5 @@ indicator: 16.10.2
 layout: indicator
 permalink: /16-10-2/
 ---
-**Non-statistical indicator**
 
-We have identified the following policies relevant to this indicator: [Freedom of Information Act 2000](https://www.legislation.gov.uk/ukpga/2000/36/contents).
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions please contact us at <SustainableDevelopment@ons.gov.uk>.

--- a/_indicators/16-2-1.md
+++ b/_indicators/16-2-1.md
@@ -3,8 +3,5 @@ indicator: 16.2.1
 layout: indicator
 permalink: /16-2-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/16-2-2.md
+++ b/_indicators/16-2-2.md
@@ -3,8 +3,5 @@ indicator: 16.2.2
 layout: indicator
 permalink: /16-2-2/
 ---
-**Statistics in progress** 
 
-We are currently corresponding with topic experts about data for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/16-2-3.md
+++ b/_indicators/16-2-3.md
@@ -3,8 +3,5 @@ indicator: 16.2.3
 layout: indicator
 permalink: /16-2-3/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and been identified in collaboration with topic experts. We will work to identify or develop UK data to meet the global indicator specification.
 
-Data availability within the UK is limited to England and Wales for this indicator.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+

--- a/_indicators/16-3-1.md
+++ b/_indicators/16-3-1.md
@@ -3,9 +3,5 @@ indicator: 16.3.1
 layout: indicator
 permalink: /16-3-1/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and has been identified in collaboration with topic experts. We will work to develop UK data to meet the global indicator specification.
-
-Data availability within the UK is limited to England and Wales for this indicator.
 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/16-3-2.md
+++ b/_indicators/16-3-2.md
@@ -3,8 +3,5 @@ indicator: 16.3.2
 layout: indicator
 permalink: /16-3-2/
 ---
-Data follows the UN specification for this indicator; however it has not been identified in collaboration with topic experts. As with all indicators, this will be reviewed.
-  
-Data availability within the UK is limited to England and Wales for this indicator.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+
+

--- a/_indicators/16-4-1.md
+++ b/_indicators/16-4-1.md
@@ -3,8 +3,5 @@ indicator: 16.4.1
 layout: indicator
 permalink: /16-4-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/16-4-2.md
+++ b/_indicators/16-4-2.md
@@ -3,8 +3,5 @@ indicator: 16.4.2
 layout: indicator
 permalink: /16-4-2/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/16-5-1.md
+++ b/_indicators/16-5-1.md
@@ -3,8 +3,5 @@ indicator: 16.5.1
 layout: indicator
 permalink: /16-5-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/16-5-2.md
+++ b/_indicators/16-5-2.md
@@ -3,8 +3,5 @@ indicator: 16.5.2
 layout: indicator
 permalink: /16-5-2/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/16-6-1.md
+++ b/_indicators/16-6-1.md
@@ -3,8 +3,5 @@ indicator: 16.6.1
 layout: indicator
 permalink: /16-6-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/16-6-2.md
+++ b/_indicators/16-6-2.md
@@ -3,8 +3,5 @@ indicator: 16.6.2
 layout: indicator
 permalink: /16-6-2/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/16-7-1.md
+++ b/_indicators/16-7-1.md
@@ -3,8 +3,5 @@ indicator: 16.7.1
 layout: indicator
 permalink: /16-7-1/
 ---
-Data follows the UN specification for this indicator; however it has not been identified in collaboration with topic experts. As with all indicators, this will be reviewed.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/16-7-2.md
+++ b/_indicators/16-7-2.md
@@ -3,8 +3,5 @@ indicator: 16.7.2
 layout: indicator
 permalink: /16-7-2/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/16-8-1.md
+++ b/_indicators/16-8-1.md
@@ -3,8 +3,5 @@ indicator: 16.8.1
 layout: indicator
 permalink: /16-8-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/16-9-1.md
+++ b/_indicators/16-9-1.md
@@ -3,8 +3,5 @@ indicator: 16.9.1
 layout: indicator
 permalink: /16-9-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/16-a-1.md
+++ b/_indicators/16-a-1.md
@@ -3,8 +3,5 @@ indicator: 16.a.1
 layout: indicator
 permalink: /16-a-1/
 ---
-**Non-statistical indicator**
 
-We have identified the following policies relevant to this indicator: [Human Rights Report - Fulfilling the Paris Principles (PDF 1.27 MB)](https://www.equalityhumanrights.com/sites/default/files/paris_principles.pdf).
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions please contact us at <SustainableDevelopment@ons.gov.uk>.

--- a/_indicators/16-b-1.md
+++ b/_indicators/16-b-1.md
@@ -3,8 +3,5 @@ indicator: 16.b.1
 layout: indicator
 permalink: /16-b-1/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and has not been identified in collaboration with topic experts. We will work to identify or develop UK data to meet the global indicator specification.
-  
-Data availability within the UK is limited to England and Wales for this indicator.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+
+

--- a/_indicators/17-1-1.md
+++ b/_indicators/17-1-1.md
@@ -3,8 +3,5 @@ indicator: 17.1.1
 layout: indicator
 permalink: /17-1-1/
 ---
-Data follows the UN specification for this indicator and has been indentified in collaboration with topic experts.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/17-1-2.md
+++ b/_indicators/17-1-2.md
@@ -3,8 +3,5 @@ indicator: 17.1.2
 layout: indicator
 permalink: /17-1-2/
 ---
-Data follows the UN specification for this indicator and has been indentified in collaboration with topic experts.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/17-10-1.md
+++ b/_indicators/17-10-1.md
@@ -3,8 +3,5 @@ indicator: 17.10.1
 layout: indicator
 permalink: /17-10-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/17-11-1.md
+++ b/_indicators/17-11-1.md
@@ -3,8 +3,5 @@ indicator: 17.11.1
 layout: indicator
 permalink: /17-11-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/17-12-1.md
+++ b/_indicators/17-12-1.md
@@ -3,8 +3,5 @@ indicator: 17.12.1
 layout: indicator
 permalink: /17-12-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>.

--- a/_indicators/17-13-1.md
+++ b/_indicators/17-13-1.md
@@ -3,8 +3,5 @@ indicator: 17.13.1
 layout: indicator
 permalink: /17-13-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/17-14-1.md
+++ b/_indicators/17-14-1.md
@@ -3,8 +3,5 @@ indicator: 17.14.1
 layout: indicator
 permalink: /17-14-1/
 ---
-**Non-statistical indicator**
 
-We have identified the following policies relevant to this indicator: [Agenda 2030: Delivering the Global Goals] (https://www.gov.uk/government/publications/agenda-2030-delivering-the-global-goals).
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions please contact us at <SustainableDevelopment@ons.gov.uk>.

--- a/_indicators/17-15-1.md
+++ b/_indicators/17-15-1.md
@@ -3,8 +3,5 @@ indicator: 17.15.1
 layout: indicator
 permalink: /17-15-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/17-16-1.md
+++ b/_indicators/17-16-1.md
@@ -3,8 +3,5 @@ indicator: 17.16.1
 layout: indicator
 permalink: /17-16-1/
 ---
-**Non-statistical indicator**
 
-We have identified the following policies relevant to this indicator: [Agenda 2030: Delivering the Global Goals] (https://www.gov.uk/government/publications/agenda-2030-delivering-the-global-goals).
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions please contact us at <SustainableDevelopment@ons.gov.uk>.

--- a/_indicators/17-17-1.md
+++ b/_indicators/17-17-1.md
@@ -3,8 +3,5 @@ indicator: 17.17.1
 layout: indicator
 permalink: /17-17-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/17-18-1.md
+++ b/_indicators/17-18-1.md
@@ -3,8 +3,5 @@ indicator: 17.18.1
 layout: indicator
 permalink: /17-18-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/17-18-2.md
+++ b/_indicators/17-18-2.md
@@ -3,8 +3,5 @@ indicator: 17.18.2
 layout: indicator
 permalink: /17-18-2/
 ---
-**Statistics in progress**               
 
-This is not a statistical indicator. However, we will collaborate with the policy lead in the UK so that we are able to link to the relevant legislative framework.
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/17-18-3.md
+++ b/_indicators/17-18-3.md
@@ -3,8 +3,5 @@ indicator: 17.18.3
 layout: indicator
 permalink: /17-18-3/
 ---
-**Statistics in progress**               
 
-This is not a statistical indicator. However, we will collaborate with the policy lead in the UK so that we are able to link to the relevant legislative framework.
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/17-19-1.md
+++ b/_indicators/17-19-1.md
@@ -3,8 +3,5 @@ indicator: 17.19.1
 layout: indicator
 permalink: /17-19-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/17-19-2.md
+++ b/_indicators/17-19-2.md
@@ -3,8 +3,5 @@ indicator: 17.19.2
 layout: indicator
 permalink: /17-19-2/
 ---
-**Non-statistical indicator**
 
-We have identified the following policies relevant to this indicator: Census for [England and Wales](https://www.ons.gov.uk/census), [Scotland](http://www.scotlandscensus.gov.uk/) and [Northern Ireland](https://www.nisra.gov.uk/statistics/census)
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions please contact us at <SustainableDevelopment@ons.gov.uk>.

--- a/_indicators/17-2-1.md
+++ b/_indicators/17-2-1.md
@@ -3,8 +3,5 @@ indicator: 17.2.1
 layout: indicator
 permalink: /17-2-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/17-3-1.md
+++ b/_indicators/17-3-1.md
@@ -3,8 +3,5 @@ indicator: 17.3.1
 layout: indicator
 permalink: /17-3-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/17-3-2.md
+++ b/_indicators/17-3-2.md
@@ -3,8 +3,5 @@ indicator: 17.3.2
 layout: indicator
 permalink: /17-3-2/
 ---
-**Statistics in progress**
 
-A potential data source has been identified. Further work is needed for this indicator.
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/17-4-1.md
+++ b/_indicators/17-4-1.md
@@ -3,8 +3,5 @@ indicator: 17.4.1
 layout: indicator
 permalink: /17-4-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/17-5-1.md
+++ b/_indicators/17-5-1.md
@@ -3,8 +3,5 @@ indicator: 17.5.1
 layout: indicator
 permalink: /17-5-1/
 ---
-**Statistics in progress**              
 
-This is not a statistical indicator. However, we will collaborate with the policy lead in the UK so that we are able to link to the relevant legislative framework.
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/17-6-1.md
+++ b/_indicators/17-6-1.md
@@ -3,8 +3,5 @@ indicator: 17.6.1
 layout: indicator
 permalink: /17-6-1/
 ---
-**Statistics in progress**              
 
-This is not a statistical indicator. However, we will collaborate with the policy lead in the UK so that we are able to link to the relevant legislative framework.
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/17-6-2.md
+++ b/_indicators/17-6-2.md
@@ -3,8 +3,5 @@ indicator: 17.6.2
 layout: indicator
 permalink: /17-6-2/
 ---
-Data follows the UN specification for this indicator and has been indentified in collaboration with topic experts.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/17-7-1.md
+++ b/_indicators/17-7-1.md
@@ -3,8 +3,5 @@ indicator: 17.7.1
 layout: indicator
 permalink: /17-7-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/17-8-1.md
+++ b/_indicators/17-8-1.md
@@ -3,8 +3,5 @@ indicator: 17.8.1
 layout: indicator
 permalink: /17-8-1/
 ---
-Data follows the UN specification for this indicator and has been indentified in collaboration with topic experts.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/17-9-1.md
+++ b/_indicators/17-9-1.md
@@ -3,8 +3,5 @@ indicator: 17.9.1
 layout: indicator
 permalink: /17-9-1/
 ---
-Data follows the UN specification for this indicator; however it has not been identified in collaboration with topic experts. As with all indicators, this will be reviewed.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/2-1-1.md
+++ b/_indicators/2-1-1.md
@@ -3,8 +3,5 @@ indicator: 2.1.1
 layout: indicator
 permalink: /2-1-1/
 ---
-**Exploring data sources**           
 
-A potential data source has been identified. Further work is needed for this indicator.
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/2-1-2.md
+++ b/_indicators/2-1-2.md
@@ -3,8 +3,5 @@ indicator: 2.1.2
 layout: indicator
 permalink: /2-1-2/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and has not been identified in collaboration with topic experts. We will work to identify or develop UK data to meet the global indicator specification.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/2-2-1.md
+++ b/_indicators/2-2-1.md
@@ -3,8 +3,5 @@ indicator: 2.2.1
 layout: indicator
 permalink: /2-2-1/
 ---
-**Exploring data sources**           
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/2-2-2.md
+++ b/_indicators/2-2-2.md
@@ -3,8 +3,5 @@ indicator: 2.2.2
 layout: indicator
 permalink: /2-2-2/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/2-3-1.md
+++ b/_indicators/2-3-1.md
@@ -3,8 +3,5 @@ indicator: 2.3.1
 layout: indicator
 permalink: /2-3-1/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and has not been identified in collaboration with topic experts. We will work to identify or develop UK data to meet the global indicator specification.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/2-3-2.md
+++ b/_indicators/2-3-2.md
@@ -3,8 +3,5 @@ indicator: 2.3.2
 layout: indicator
 permalink: /2-3-2/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and has not been identified in collaboration with topic experts. We will work to identify or develop UK data to meet the global indicator specification.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/2-4-1.md
+++ b/_indicators/2-4-1.md
@@ -3,4 +3,5 @@ indicator: 2.4.1
 layout: indicator
 permalink: /2-4-1/
 ---
-We are still looking for a suitable data source for this indicator. Please contact us if you think you can help by emailing <SustainableDevelopment@ons.gov.uk>
+
+

--- a/_indicators/2-5-1.md
+++ b/_indicators/2-5-1.md
@@ -3,9 +3,5 @@ indicator: 2.5.1
 layout: indicator
 permalink: /2-5-1/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and has not been identified in collaboration with topic experts. We will work to identify or develop UK data to meet the global indicator specification.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
-
 
 

--- a/_indicators/2-5-2.md
+++ b/_indicators/2-5-2.md
@@ -3,5 +3,5 @@ indicator: 2.5.2
 layout: indicator
 permalink: /2-5-2/
 ---
-We are currently corresponding with the topic expert for this indicator.
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk> 
+
+

--- a/_indicators/2-a-1.md
+++ b/_indicators/2-a-1.md
@@ -3,8 +3,5 @@ indicator: 2.a.1
 layout: indicator
 permalink: /2-a-1/
 ---
-Data follows the UN specification for this indicator; however it has not been identified in collaboration with topic experts. As with all indicators, this will be reviewed.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/2-a-2.md
+++ b/_indicators/2-a-2.md
@@ -3,8 +3,5 @@ indicator: 2.a.2
 layout: indicator
 permalink: /2-a-2/
 ---
-Data follows the UN specification for this indicator; however it has not been identified in collaboration with topic experts. As with all indicators, this will be reviewed.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/2-b-1.md
+++ b/_indicators/2-b-1.md
@@ -3,8 +3,5 @@ indicator: 2.b.1
 layout: indicator
 permalink: /2-b-1/
 ---
-**Exploring data sources**           
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/2-c-1.md
+++ b/_indicators/2-c-1.md
@@ -3,8 +3,5 @@ indicator: 2.c.1
 layout: indicator
 permalink: /2-c-1/
 ---
-**Exploring data sources**                     
 
-A potential data source has been identified. Further work is needed for this indicator.
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/3-1-1.md
+++ b/_indicators/3-1-1.md
@@ -3,8 +3,5 @@ indicator: 3.1.1
 layout: indicator
 permalink: /3-1-1/
 ---
-**Statistics in progress**                   
 
-We are currently corresponding with topic experts about data for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/3-1-2.md
+++ b/_indicators/3-1-2.md
@@ -3,10 +3,5 @@ indicator: 3.1.2
 layout: indicator
 permalink: /3-1-2/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and has not been identified in collaboration with topic experts. We will work to identify or develop UK data to meet the global indicator specification.
 
-Home births will on many occasions have a skilled health professional present (a midwife) as some women choose to have a home birth so a midwife attends. There will be some home births which occur without a midwife but an ambulance is sent and arrives just before or soon after the birth - these are births which happen too quick for the mother to get to hospital.
-  
-Data availability within the UK is limited to England and Wales for this indicator.
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/3-2-1.md
+++ b/_indicators/3-2-1.md
@@ -3,8 +3,5 @@ indicator: 3.2.1
 layout: indicator
 permalink: /3-2-1/
 ---
-Data follows the UN specification for this indicator and has been indentified in collaboration with topic experts.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/3-2-2.md
+++ b/_indicators/3-2-2.md
@@ -3,6 +3,5 @@ indicator: 3.2.2
 layout: indicator
 permalink: /3-2-2/
 ---
-Data follows the UN specification for this indicator and has been indentified in collaboration with topic experts.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+
+

--- a/_indicators/3-3-1.md
+++ b/_indicators/3-3-1.md
@@ -3,6 +3,5 @@ indicator: 3.3.1
 layout: indicator
 permalink: /3-3-1/
 ---
-Data follows the UN specification for this indicator; however it has not been identified in collaboration with topic experts. As with all indicators, this will be reviewed.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+
+

--- a/_indicators/3-3-2.md
+++ b/_indicators/3-3-2.md
@@ -3,6 +3,5 @@ indicator: 3.3.2
 layout: indicator
 permalink: /3-3-2/
 ---
-Data follows the UN specification for this indicator and has been indentified in collaboration with topic experts.
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+

--- a/_indicators/3-3-3.md
+++ b/_indicators/3-3-3.md
@@ -3,6 +3,5 @@ indicator: 3.3.3
 layout: indicator
 permalink: /3-3-3/
 ---
-Data follows the UN specification for this indicator; however it has not been identified in collaboration with topic experts. As with all indicators, this will be reviewed.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+
+

--- a/_indicators/3-3-4.md
+++ b/_indicators/3-3-4.md
@@ -3,6 +3,5 @@ indicator: 3.3.4
 layout: indicator
 permalink: /3-3-4/
 ---
-Data follows the UN specification for this indicator and has been indentified in collaboration with topic experts. Data availability within the UK is limited to England for this indicator.
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+

--- a/_indicators/3-3-5.md
+++ b/_indicators/3-3-5.md
@@ -3,8 +3,5 @@ indicator: 3.3.5
 layout: indicator
 permalink: /3-3-5/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/3-4-1.md
+++ b/_indicators/3-4-1.md
@@ -3,6 +3,5 @@ indicator: 3.4.1
 layout: indicator
 permalink: /3-4-1/
 ---
-Data follows the UN specification for this indicator and has been indentified in collaboration with topic experts. Data availability within the UK is limited to England and Wales for this indicator.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+
+

--- a/_indicators/3-4-2.md
+++ b/_indicators/3-4-2.md
@@ -3,8 +3,5 @@ indicator: 3.4.2
 layout: indicator
 permalink: /3-4-2/
 ---
-Data follows the UN specification for this indicator; however it has not been identified in collaboration with topic experts. As with all indicators, this will be reviewed.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/3-5-1.md
+++ b/_indicators/3-5-1.md
@@ -3,8 +3,5 @@ indicator: 3.5.1
 layout: indicator
 permalink: /3-5-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/3-5-2.md
+++ b/_indicators/3-5-2.md
@@ -3,6 +3,5 @@ indicator: 3.5.2
 layout: indicator
 permalink: /3-5-2/
 ---
-Data follows the UN specification for this indicator; however it has not been identified in collaboration with topic experts. As with all indicators, this will be reviewed.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+
+

--- a/_indicators/3-6-1.md
+++ b/_indicators/3-6-1.md
@@ -3,8 +3,5 @@ indicator: 3.6.1
 layout: indicator
 permalink: /3-6-1/
 ---
-Data follows the UN specification for this indicator; however it has not been identified in collaboration with topic experts. As with all indicators, this will be reviewed.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/3-7-1.md
+++ b/_indicators/3-7-1.md
@@ -3,8 +3,5 @@ indicator: 3.7.1
 layout: indicator
 permalink: /3-7-1/
 ---
-**Statistics in progress**
 
-We are currently corresponding with topic experts about data for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/3-7-2.md
+++ b/_indicators/3-7-2.md
@@ -3,8 +3,5 @@ indicator: 3.7.2
 layout: indicator
 permalink: /3-7-2/
 ---
-Data follows the UN specification for this indicator; however it has not been identified in collaboration with topic experts. As with all indicators, this will be reviewed.
-  
-Data availability within the UK is limited to England and Wales for this indicator.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+
+

--- a/_indicators/3-8-1.md
+++ b/_indicators/3-8-1.md
@@ -3,8 +3,5 @@ indicator: 3.8.1
 layout: indicator
 permalink: /3-8-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/3-8-2.md
+++ b/_indicators/3-8-2.md
@@ -3,8 +3,5 @@ indicator: 3.8.2
 layout: indicator
 permalink: /3-8-2/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and has been identified in collaboration with topic experts. We will work to develop UK data to meet the global indicator specification.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/3-9-1.md
+++ b/_indicators/3-9-1.md
@@ -3,8 +3,5 @@ indicator: 3.9.1
 layout: indicator
 permalink: /3-9-1/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and has not been identified in collaboration with topic experts. We will work to identify or develop UK data to meet the global indicator specification.
 
-Data availability within the UK is limited to England for this indicator.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+

--- a/_indicators/3-9-2.md
+++ b/_indicators/3-9-2.md
@@ -3,8 +3,5 @@ indicator: 3.9.2
 layout: indicator
 permalink: /3-9-2/
 ---
-Data follows the UN specification for this indicator; however it has not been identified in collaboration with topic experts. As with all indicators, this will be reviewed.
-  
-Data availability within the UK is limited to England and Wales for this indicator.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+
+

--- a/_indicators/3-9-3.md
+++ b/_indicators/3-9-3.md
@@ -3,8 +3,5 @@ indicator: 3.9.3
 layout: indicator
 permalink: /3-9-3/
 ---
-Data follows the UN specification for this indicator; however it has not been identified in collaboration with topic experts. As with all indicators, this will be reviewed.
-  
-Data availability within the UK is limited to United Kingdom for this indicator.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+
+

--- a/_indicators/3-a-1.md
+++ b/_indicators/3-a-1.md
@@ -3,8 +3,5 @@ indicator: 3.a.1
 layout: indicator
 permalink: /3-a-1/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and has been identified in collaboration with topic experts. We will work to develop UK data to meet the global indicator specification.
-  
-Data availability within the UK is limited to Great Britain for this indicator.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+
+

--- a/_indicators/3-b-1.md
+++ b/_indicators/3-b-1.md
@@ -3,8 +3,5 @@ indicator: 3.b.1
 layout: indicator
 permalink: /3-b-1/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and has not been identified in collaboration with topic experts. We will work to identify or develop UK data to meet the global indicator specification.
 
-Data availability within the UK is limited to England for this indicator.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+

--- a/_indicators/3-b-2.md
+++ b/_indicators/3-b-2.md
@@ -3,8 +3,5 @@ indicator: 3.b.2
 layout: indicator
 permalink: /3-b-2/
 ---
-Data follows the UN specification for this indicator; however it has not been identified in collaboration with topic experts. As with all indicators, this will be reviewed.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/3-b-3.md
+++ b/_indicators/3-b-3.md
@@ -3,8 +3,5 @@ indicator: 3.b.3
 layout: indicator
 permalink: /3-b-3/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/3-c-1.md
+++ b/_indicators/3-c-1.md
@@ -3,6 +3,5 @@ indicator: 3.c.1
 layout: indicator
 permalink: /3-c-1/
 ---
-Data follows the UN specification for this indicator; however it has not been identified in collaboration with topic experts. As with all indicators, this will be reviewed.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+
+

--- a/_indicators/3-d-1.md
+++ b/_indicators/3-d-1.md
@@ -3,8 +3,5 @@ indicator: 3.d.1
 layout: indicator
 permalink: /3-d-1/
 ---
-**Statistics in progress**               
 
-A potential data source has been identified. Further work is needed for this indicator.
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/4-1-1.md
+++ b/_indicators/4-1-1.md
@@ -3,8 +3,5 @@ indicator: 4.1.1
 layout: indicator
 permalink: /4-1-1/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and has not been identified in collaboration with topic experts. We will work to identify or develop UK data to meet the global indicator specification.
-  
-Data availability within the UK is limited to England for this indicator.
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+

--- a/_indicators/4-2-1.md
+++ b/_indicators/4-2-1.md
@@ -3,8 +3,5 @@ indicator: 4.2.1
 layout: indicator
 permalink: /4-2-1/
 ---
-Data follows the UN specification for this indicator; however it has not been identified in collaboration with topic experts. As with all indicators, this will be reviewed.
-  
-Data availability within the UK is limited to England for this indicator.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+
+

--- a/_indicators/4-2-2.md
+++ b/_indicators/4-2-2.md
@@ -3,8 +3,5 @@ indicator: 4.2.2
 layout: indicator
 permalink: /4-2-2/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and has not been identified in collaboration with topic experts. We will work to identify or develop UK data to meet the global indicator specification.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/4-3-1.md
+++ b/_indicators/4-3-1.md
@@ -3,8 +3,5 @@ indicator: 4.3.1
 layout: indicator
 permalink: /4-3-1/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and has not been identified in collaboration with topic experts. We will work to identify or develop UK data to meet the global indicator specification.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/4-4-1.md
+++ b/_indicators/4-4-1.md
@@ -3,8 +3,5 @@ indicator: 4.4.1
 layout: indicator
 permalink: /4-4-1/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and has not been identified in collaboration with topic experts. We will work to identify or develop UK data to meet the global indicator specification.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/4-5-1.md
+++ b/_indicators/4-5-1.md
@@ -3,8 +3,5 @@ indicator: 4.5.1
 layout: indicator
 permalink: /4-5-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/4-6-1.md
+++ b/_indicators/4-6-1.md
@@ -3,8 +3,5 @@ indicator: 4.6.1
 layout: indicator
 permalink: /4-6-1/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and has not been identified in collaboration with topic experts. We will work to identify or develop UK data to meet the global indicator specification.
 
-Data availability within the UK is limited to England for this indicator.
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/4-7-1.md
+++ b/_indicators/4-7-1.md
@@ -3,26 +3,5 @@ indicator: 4.7.1
 layout: indicator
 permalink: /4-7-1/
 ---
-**Non-statistical indicator**
 
-Education in the UK is devolved, and so there is some variance in the approach to Education for Sustainable Development (ESD). We have therefore identified relevant policy/legislation by country, as well as the official curriculum and some supporting case studies.
 
-*England*
-
-[National Curriculum](https://www.gov.uk/government/collections/national-curriculum)
-
-*Northern Ireland*
-
-[Overview of the Northern Ireland Curriculum](http://ccea.org.uk/curriculum/overview)
-
-*Scotland*
-
-[Curriculum for Excellence](http://www.gov.scot/resource/doc/226155/0061245.pdf) and [Learning for Sustainability (DOC 33 KB)](http://www.gov.scot/resource/0041/00416172.docx)
-
-*Wales*
-
-[Curriculum](http://learning.gov.wales/resources/improvementareas/curriculum/?lang=en), [Well-being of Future Generations (Wales) Act 2015](http://www.legislation.gov.uk/anaw/2015/2/contents/enacted) (see Goal 4 in particular) and [Education for Sustainable Development and Global Citizenship](http://learning.gov.wales/resources/browse-all/education-for-sustainable-development-and-global-citizenship/?lang=en)
-
-A support document showing relevant ESD case studies can be found in [‘Good practice in Education for Sustainable Development (ESD) in the UK: Case Studies’ (PDF 165 KB)](https://www.unesco.org.uk/wp-content/uploads/2017/04/UKNC-Case-Study-1-FINAL.pdf).
-
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions please contact us at <SustainableDevelopment@ons.gov.uk>.

--- a/_indicators/4-a-1.md
+++ b/_indicators/4-a-1.md
@@ -3,8 +3,5 @@ indicator: 4.a.1
 layout: indicator
 permalink: /4-a-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/4-b-1.md
+++ b/_indicators/4-b-1.md
@@ -3,8 +3,5 @@ indicator: 4.b.1
 layout: indicator
 permalink: /4-b-1/
 ---
-Data follows the UN specification for this indicator; however it has not been identified in collaboration with topic experts. As with all indicators, this will be reviewed.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/4-c-1.md
+++ b/_indicators/4-c-1.md
@@ -3,8 +3,5 @@ indicator: 4.c.1
 layout: indicator
 permalink: /4-c-1/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and has not been identified in collaboration with topic experts. We will work to identify or develop UK data to meet the global indicator specification.
 
-Data availability within the UK is limited to England for this indicator.
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/5-1-1.md
+++ b/_indicators/5-1-1.md
@@ -3,8 +3,5 @@ indicator: 5.1.1
 layout: indicator
 permalink: /5-1-1/
 ---
-**Non-statistical indicator**
 
-We have identified the following policies relevant to this indicator: [Equality Act 2010](https://www.gov.uk/guidance/equality-act-2010-guidance).
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions please contact us at <SustainableDevelopment@ons.gov.uk>.

--- a/_indicators/5-2-1.md
+++ b/_indicators/5-2-1.md
@@ -3,8 +3,5 @@ indicator: 5.2.1
 layout: indicator
 permalink: /5-2-1/
 ---
-Data follows the UN specification for this indicator and has been indentified in collaboration with topic experts. Data availability within the UK is limited to United Kingdom for this indicator.
 
-Data availability within the UK is limited to England and Wales for this indicator.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+

--- a/_indicators/5-2-2.md
+++ b/_indicators/5-2-2.md
@@ -3,8 +3,5 @@ indicator: 5.2.2
 layout: indicator
 permalink: /5-2-2/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and has been identified in collaboration with topic experts. We will work to develop UK data to meet the global indicator specification.
-  
-Data availability within the UK is limited to England and Wales for this indicator.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+
+

--- a/_indicators/5-3-1.md
+++ b/_indicators/5-3-1.md
@@ -3,8 +3,5 @@ indicator: 5.3.1
 layout: indicator
 permalink: /5-3-1/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and has been identified in collaboration with topic experts. We will work to develop UK data to meet the global indicator specification.
-  
-Data availability within the UK is limited to England and Wales for this indicator.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+
+

--- a/_indicators/5-3-2.md
+++ b/_indicators/5-3-2.md
@@ -3,8 +3,5 @@ indicator: 5.3.2
 layout: indicator
 permalink: /5-3-2/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and has not been identified in collaboration with topic experts. We will work to identify or develop UK data to meet the global indicator specification.
 
-Data availability within the UK is limited to England for this indicator.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+

--- a/_indicators/5-4-1.md
+++ b/_indicators/5-4-1.md
@@ -3,8 +3,5 @@ indicator: 5.4.1
 layout: indicator
 permalink: /5-4-1/
 ---
-Data follows the UN specification for this indicator and has been indentified in collaboration with topic experts.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/5-5-1.md
+++ b/_indicators/5-5-1.md
@@ -3,8 +3,5 @@ indicator: 5.5.1
 layout: indicator
 permalink: /5-5-1/
 ---
-Data follows the UN specification for this indicator; however it has not been identified in collaboration with topic experts. As with all indicators, this will be reviewed.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/5-5-2.md
+++ b/_indicators/5-5-2.md
@@ -3,8 +3,5 @@ indicator: 5.5.2
 layout: indicator
 permalink: /5-5-2/
 ---
-Data follows the UN specification for this indicator; however it has not been identified in collaboration with topic experts. As with all indicators, this will be reviewed.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/5-6-1.md
+++ b/_indicators/5-6-1.md
@@ -3,8 +3,5 @@ indicator: 5.6.1
 layout: indicator
 permalink: /5-6-1/
 ---
-**Statistics in progress**
 
-We are currently corresponding with topic experts about data for this indicator.
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/5-6-2.md
+++ b/_indicators/5-6-2.md
@@ -3,8 +3,5 @@ indicator: 5.6.2
 layout: indicator
 permalink: /5-6-2/
 ---
-**Non-statistical indicator**
 
-We have identified the following policies relevant to this indicator: A Framework for Sexual Health Improvement for [England](https://www.gov.uk/government/publications/a-framework-for-sexual-health-improvement-in-england), [Scotland](http://www.gov.scot/Resource/Doc/35596/0012575.pdf) and [Wales](http://www.wales.nhs.uk/sites3/documents/485/Strategy%20(English)1.pdf).
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions please contact us at <SustainableDevelopment@ons.gov.uk>.

--- a/_indicators/5-a-1.md
+++ b/_indicators/5-a-1.md
@@ -3,8 +3,5 @@ indicator: 5.a.1
 layout: indicator
 permalink: /5-a-1/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and has not been identified in collaboration with topic experts. We will work to identify or develop UK data to meet the global indicator specification.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/5-a-2.md
+++ b/_indicators/5-a-2.md
@@ -3,8 +3,5 @@ indicator: 5.a.2
 layout: indicator
 permalink: /5-a-2/
 ---
-**Non-statistical indicator**
 
-We have identified the following policies relevant to this indicator: [Equality Act 2010](https://www.gov.uk/guidance/equality-act-2010-guidance).
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions please contact us at <SustainableDevelopment@ons.gov.uk>.

--- a/_indicators/5-b-1.md
+++ b/_indicators/5-b-1.md
@@ -3,8 +3,5 @@ indicator: 5.b.1
 layout: indicator
 permalink: /5-b-1/
 ---
-Data follows the UN specification for this indicator and has been indentified in collaboration with topic experts.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/5-c-1.md
+++ b/_indicators/5-c-1.md
@@ -3,8 +3,5 @@ indicator: 5.c.1
 layout: indicator
 permalink: /5-c-1/
 ---
-**Non-statistical indicator**
 
-We have identified the following policies relevant to this indicator: [The Equality Act 2010 (Gender Pay Gap Information) Regulations 2017](https://www.legislation.gov.uk/ukdsi/2017/9780111152010).
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions please contact us at <SustainableDevelopment@ons.gov.uk>.

--- a/_indicators/6-1-1.md
+++ b/_indicators/6-1-1.md
@@ -3,8 +3,5 @@ indicator: 6.1.1
 layout: indicator
 permalink: /6-1-1/
 ---
-**Exploring data sources**   
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/6-2-1.md
+++ b/_indicators/6-2-1.md
@@ -3,8 +3,5 @@ indicator: 6.2.1
 layout: indicator
 permalink: /6-2-1/
 ---
-**Exploring data sources**  
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/6-3-1.md
+++ b/_indicators/6-3-1.md
@@ -3,8 +3,5 @@ indicator: 6.3.1
 layout: indicator
 permalink: /6-3-1/
 ---
-**Exploring data sources**    
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/6-3-2.md
+++ b/_indicators/6-3-2.md
@@ -3,8 +3,5 @@ indicator: 6.3.2
 layout: indicator
 permalink: /6-3-2/
 ---
-Data follows the UN specification for this indicator; however it has not been identified in collaboration with topic experts. As with all indicators, this will be reviewed.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/6-4-1.md
+++ b/_indicators/6-4-1.md
@@ -3,8 +3,5 @@ indicator: 6.4.1
 layout: indicator
 permalink: /6-4-1/
 ---
-**Statistics in progress**             
 
-We are currently corresponding with topic experts about data for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/6-4-2.md
+++ b/_indicators/6-4-2.md
@@ -3,8 +3,5 @@ indicator: 6.4.2
 layout: indicator
 permalink: /6-4-2/
 ---
-**Statistics in progress**
 
-We are currently corresponding with topic experts about data for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/6-5-1.md
+++ b/_indicators/6-5-1.md
@@ -3,6 +3,5 @@ indicator: 6.5.1
 layout: indicator
 permalink: /6-5-1/
 ---
-Data follows the UN specification for this indicator and has been indentified in collaboration with topic experts.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+
+

--- a/_indicators/6-5-2.md
+++ b/_indicators/6-5-2.md
@@ -3,6 +3,5 @@ indicator: 6.5.2
 layout: indicator
 permalink: /6-5-2/
 ---
-Data follows the UN specification for this indicator and has been indentified in collaboration with topic experts.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+
+

--- a/_indicators/6-6-1.md
+++ b/_indicators/6-6-1.md
@@ -3,8 +3,5 @@ indicator: 6.6.1
 layout: indicator
 permalink: /6-6-1/
 ---
-**Exploring data sources**        
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/6-a-1.md
+++ b/_indicators/6-a-1.md
@@ -3,8 +3,5 @@ indicator: 6.a.1
 layout: indicator
 permalink: /6-a-1/
 ---
-Data follows the UN specification for this indicator; however it has not been identified in collaboration with topic experts. As with all indicators, this will be reviewed.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/6-b-1.md
+++ b/_indicators/6-b-1.md
@@ -3,8 +3,5 @@ indicator: 6.b.1
 layout: indicator
 permalink: /6-b-1/
 ---
-**Exploring data sources**   
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/7-1-1.md
+++ b/_indicators/7-1-1.md
@@ -3,11 +3,5 @@ indicator: 7.1.1
 layout: indicator
 permalink: /7-1-1/
 ---
-Data for this indicator has been sourced from the UN SDG database. As with all indicators, this will be reviewed.
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
-
-
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/7-1-2.md
+++ b/_indicators/7-1-2.md
@@ -3,8 +3,5 @@ indicator: 7.1.2
 layout: indicator
 permalink: /7-1-2/
 ---
-Data follows the UN specification for this indicator and has been indentified in collaboration with topic experts.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/7-2-1.md
+++ b/_indicators/7-2-1.md
@@ -3,8 +3,5 @@ indicator: 7.2.1
 layout: indicator
 permalink: /7-2-1/
 ---
-Data follows the UN specification for this indicator and has been indentified in collaboration with topic experts.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/7-3-1.md
+++ b/_indicators/7-3-1.md
@@ -3,8 +3,5 @@ indicator: 7.3.1
 layout: indicator
 permalink: /7-3-1/
 ---
-Data follows the UN specification for this indicator; however it has not been identified in collaboration with topic experts. As with all indicators, this will be reviewed.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/7-a-1.md
+++ b/_indicators/7-a-1.md
@@ -3,8 +3,5 @@ indicator: 7.a.1
 layout: indicator
 permalink: /7-a-1/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and has not been identified in collaboration with topic experts. We will work to identify or develop UK data to meet the global indicator specification.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/7-b-1.md
+++ b/_indicators/7-b-1.md
@@ -3,10 +3,5 @@ indicator: 7.b.1
 layout: indicator
 permalink: /7-b-1/
 ---
-**Proxy indicator (Expert Led)**              
 
-This indicator is being used as an approximation of the UN SDG Indicator and has been developed in collaboration with the topic expert. We will work to develop UK data to meet the global indicator specifications.
 
-The Sustainable Development Goals is a collaborative project. If you have any feedback or suggestions for data please contact us at SustainableDevelopment@ons.gov.uk.
-
-*Note: Values of <500 have been removed from the CSV.*

--- a/_indicators/8-1-1.md
+++ b/_indicators/8-1-1.md
@@ -3,8 +3,5 @@ indicator: 8.1.1
 layout: indicator
 permalink: /8-1-1/
 ---
-Data follows the UN specification for this indicator and has been indentified in collaboration with topic experts.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/8-10-1.md
+++ b/_indicators/8-10-1.md
@@ -3,8 +3,5 @@ indicator: 8.10.1
 layout: indicator
 permalink: /8-10-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/8-10-2.md
+++ b/_indicators/8-10-2.md
@@ -3,8 +3,5 @@ indicator: 8.10.2
 layout: indicator
 permalink: /8-10-2/
 ---
-Data follows the UN specification for this indicator; however it has not been identified in collaboration with topic experts. As with all indicators, this will be reviewed.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/8-2-1.md
+++ b/_indicators/8-2-1.md
@@ -3,8 +3,5 @@ indicator: 8.2.1
 layout: indicator
 permalink: /8-2-1/
 ---
-Data follows the UN specification for this indicator and has been indentified in collaboration with topic experts.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/8-3-1.md
+++ b/_indicators/8-3-1.md
@@ -3,8 +3,5 @@ indicator: 8.3.1
 layout: indicator
 permalink: /8-3-1/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and has not been identified in collaboration with topic experts. We will work to identify or develop UK data to meet the global indicator specification.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/8-4-1.md
+++ b/_indicators/8-4-1.md
@@ -3,8 +3,5 @@ indicator: 8.4.1
 layout: indicator
 permalink: /8-4-1/
 ---
-Data follows the UN specification for this indicator and has been indentified in collaboration with topic experts.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/8-4-2.md
+++ b/_indicators/8-4-2.md
@@ -3,8 +3,5 @@ indicator: 8.4.2
 layout: indicator
 permalink: /8-4-2/
 ---
-Data follows the UN specification for this indicator and has been indentified in collaboration with topic experts.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/8-5-1.md
+++ b/_indicators/8-5-1.md
@@ -3,6 +3,5 @@ indicator: 8.5.1
 layout: indicator
 permalink: /8-5-1/
 ---
-Data follows the UN specification for this indicator and has been indentified in collaboration with topic experts.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+
+

--- a/_indicators/8-5-2.md
+++ b/_indicators/8-5-2.md
@@ -3,8 +3,5 @@ indicator: 8.5.2
 layout: indicator
 permalink: /8-5-2/
 ---
-Data follows the UN specification for this indicator and has been indentified in collaboration with topic experts. Data availability within the UK is limited to United Kingdom for this indicator.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/8-6-1.md
+++ b/_indicators/8-6-1.md
@@ -3,8 +3,5 @@ indicator: 8.6.1
 layout: indicator
 permalink: /8-6-1/
 ---
-Data follows the UN specification for this indicator and has been indentified in collaboration with topic experts.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/8-7-1.md
+++ b/_indicators/8-7-1.md
@@ -3,8 +3,5 @@ indicator: 8.7.1
 layout: indicator
 permalink: /8-7-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/8-8-1.md
+++ b/_indicators/8-8-1.md
@@ -3,8 +3,5 @@ indicator: 8.8.1
 layout: indicator
 permalink: /8-8-1/
 ---
-Data follows the UN specification for this indicator; however it has not been identified in collaboration with topic experts. As with all indicators, this will be reviewed.
-  
-Data availability within the UK is limited to Great Britain for this indicator.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+
+

--- a/_indicators/8-8-2.md
+++ b/_indicators/8-8-2.md
@@ -3,8 +3,5 @@ indicator: 8.8.2
 layout: indicator
 permalink: /8-8-2/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/8-9-1.md
+++ b/_indicators/8-9-1.md
@@ -3,8 +3,5 @@ indicator: 8.9.1
 layout: indicator
 permalink: /8-9-1/
 ---
-Data follows the UN specification for this indicator and has been indentified in collaboration with topic experts.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/8-9-2.md
+++ b/_indicators/8-9-2.md
@@ -3,8 +3,5 @@ indicator: 8.9.2
 layout: indicator
 permalink: /8-9-2/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and has not been identified in collaboration with topic experts. We will work to identify or develop UK data to meet the global indicator specification.
 
-Data availability within the UK is limited to Great Britain for this indicator.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+

--- a/_indicators/8-a-1.md
+++ b/_indicators/8-a-1.md
@@ -3,8 +3,5 @@ indicator: 8.a.1
 layout: indicator
 permalink: /8-a-1/
 ---
-Data follows the UN specification for this indicator; however it has not been identified in collaboration with topic experts. As with all indicators, this will be reviewed.
-  
-Data availability within the UK is limited to United Kingdom for this indicator.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
+
+

--- a/_indicators/8-b-1.md
+++ b/_indicators/8-b-1.md
@@ -3,8 +3,5 @@ indicator: 8.b.1
 layout: indicator
 permalink: /8-b-1/
 ---
-**Non-statistical indicator**
 
-We have identified the following policies relevant to this indicator: [Education and Skills Act 2008](http://www.legislation.gov.uk/ukpga/2008/25/contents).
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions please contact us at <SustainableDevelopment@ons.gov.uk>.

--- a/_indicators/9-1-1.md
+++ b/_indicators/9-1-1.md
@@ -3,8 +3,5 @@ indicator: 9.1.1
 layout: indicator
 permalink: /9-1-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/9-1-2.md
+++ b/_indicators/9-1-2.md
@@ -3,8 +3,5 @@ indicator: 9.1.2
 layout: indicator
 permalink: /9-1-2/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and has not been identified in collaboration with topic experts. We will work to identify or develop UK data to meet the global indicator specification.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/9-2-1.md
+++ b/_indicators/9-2-1.md
@@ -3,8 +3,5 @@ indicator: 9.2.1
 layout: indicator
 permalink: /9-2-1/
 ---
-Data follows the UN specification for this indicator and has been indentified in collaboration with topic experts.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/9-2-2.md
+++ b/_indicators/9-2-2.md
@@ -3,8 +3,5 @@ indicator: 9.2.2
 layout: indicator
 permalink: /9-2-2/
 ---
-Data follows the UN specification for this indicator and has been indentified in collaboration with topic experts.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/9-3-1.md
+++ b/_indicators/9-3-1.md
@@ -3,8 +3,5 @@ indicator: 9.3.1
 layout: indicator
 permalink: /9-3-1/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and has not been identified in collaboration with topic experts. We will work to identify or develop UK data to meet the global indicator specification.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/9-3-2.md
+++ b/_indicators/9-3-2.md
@@ -3,8 +3,5 @@ indicator: 9.3.2
 layout: indicator
 permalink: /9-3-2/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_indicators/9-4-1.md
+++ b/_indicators/9-4-1.md
@@ -3,8 +3,5 @@ indicator: 9.4.1
 layout: indicator
 permalink: /9-4-1/
 ---
-Data follows the UN specification for this indicator and has been indentified in collaboration with topic experts.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/9-5-1.md
+++ b/_indicators/9-5-1.md
@@ -3,8 +3,5 @@ indicator: 9.5.1
 layout: indicator
 permalink: /9-5-1/
 ---
-Data follows the UN specification for this indicator and has been indentified in collaboration with topic experts. Data availability within the UK is limited to United Kingdom for this indicator.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/9-5-2.md
+++ b/_indicators/9-5-2.md
@@ -3,8 +3,5 @@ indicator: 9.5.2
 layout: indicator
 permalink: /9-5-2/
 ---
-Data follows the UN specification for this indicator and has been indentified in collaboration with topic experts.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/9-a-1.md
+++ b/_indicators/9-a-1.md
@@ -3,8 +3,5 @@ indicator: 9.a.1
 layout: indicator
 permalink: /9-a-1/
 ---
-Data follows the UN specification for this indicator; however it has not been identified in collaboration with topic experts. As with all indicators, this will be reviewed.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/9-b-1.md
+++ b/_indicators/9-b-1.md
@@ -3,8 +3,5 @@ indicator: 9.b.1
 layout: indicator
 permalink: /9-b-1/
 ---
-This indicator is being used as an approximation of the UN SDG Indicator and has not been identified in collaboration with topic experts. We will work to identify or develop UK data to meet the global indicator specification.
-  
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>
 
 

--- a/_indicators/9-c-1.md
+++ b/_indicators/9-c-1.md
@@ -3,8 +3,5 @@ indicator: 9.c.1
 layout: indicator
 permalink: /9-c-1/
 ---
-**Exploring data sources**
 
-We have not explored suitable data sources for this indicator. 
 
-The Sustainable Development Goals is a collaborative project, if you have any feedback or suggestions for data please contact us at <SustainableDevelopment@ons.gov.uk>

--- a/_layouts/indicator.html
+++ b/_layouts/indicator.html
@@ -53,7 +53,7 @@
   <div class="row" id="page-content-row">
     <div class="col-xs-12">
       <div id="page-content">
-        {{ page.content }}
+        {{ meta.page_content }}
       </div>
     </div>
   </div>

--- a/_layouts/indicator.html
+++ b/_layouts/indicator.html
@@ -53,7 +53,7 @@
   <div class="row" id="page-content-row">
     <div class="col-xs-12">
       <div id="page-content">
-        {{ meta.page_content }}
+        {{ meta.page_content | markdownify }}
       </div>
     </div>
   </div>


### PR DESCRIPTION
Remove the `page.content` in favour of the `meta.page_content` field. This means that this can be updated without needing to rebuild everything.