### PR TITLE
Use search.html component for search-box markup, instead of js

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -46,6 +46,7 @@
         </li> -->
       </ul>
 
+      {% include search.html %}
 
     </nav>
   </div>

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -100,7 +100,6 @@ indicatorSearch.prototype = {
 
 $(function() {
 
-  $('#main-nav').append('<div id="search" class="menu-target"><label for="indicator_search"><i class="fa fa-search" aria-hidden="true"></i><span>Search:</span></label><input id="indicator_search" title="Indicator search" placeholder="Indicator search" data-url="{{ site.baseurl }}/indicators.json" data-pageurl="{{ site.baseurl }}/search/?" /></div>');
   var $el = $('#indicator_search');
   new indicatorSearch($el, new indicatorDataStore($el.data('url')));
 


### PR DESCRIPTION
This change doesn't fix/change/add any functionality - rather is just a minor "developer experience" tweak. There is a Jekyll component in this repo called "search.html" which contains the markup for the search box in the upper right. However it's not being used, and instead there is a JavaScript snippet that duplicates that markup. This proposed change removes the JavaScript snippet and "includes" the markup using the Jekyll component.

This also facilitates future development for multilingual support: the search-box markup needs some Jekyll variables (`site.baseurl`). But including Jekyll variables in assets (like JavaScript) is problematic because the same assets are shared across all pages, even if (in the future) those pages are in different languages. By using the Jekyll component instead of JavaScript here, it will be possible to translate the markup in this component and allow multilingual searches.