### PR TITLE
Indicator sort order

### DIFF
--- a/_layouts/goal.html
+++ b/_layouts/goal.html
@@ -22,7 +22,7 @@
   {{ content }}
   {% include components/breadcrumb.html %}
 
-  {% assign goal_indicators = site.data.meta | where: 'sdg_goal', page.sdg_goal %}
+  {% assign goal_indicators = site.data.meta | where: 'sdg_goal', page.sdg_goal | sort: 'indicator_sort_order' %}
   {% for indicator in goal_indicators %}
 
     {% if indicator.reporting_status == 'notstarted' %}


### PR DESCRIPTION
Indicators have gone out of order in the staging site. Test to try and read from 'indicator_sort_order'.