### PR TITLE
pull through fix to page titles from open-sdg

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -105,7 +105,7 @@ defaults:
 plugins:
   - jekyll-remote-theme
 
-remote_theme: open-sdg/open-sdg@0.3.0
+remote_theme: open-sdg/open-sdg@606b3159e2
 
 # Mapping
 map_options:

--- a/_config_prod.yml
+++ b/_config_prod.yml
@@ -104,7 +104,7 @@ defaults:
 plugins:
   - jekyll-remote-theme
 
-remote_theme: open-sdg/open-sdg@0.3.0
+remote_theme: open-sdg/open-sdg@606b3159e2
 
 # Mapping
 map_options:

--- a/_layouts/goal.html
+++ b/_layouts/goal.html
@@ -1,3 +1,4 @@
+{% include multilingual.html %}
 {% include head.html %}
 {% include header.html %}
 {% assign goal_number = page.sdg_goal %}

--- a/_layouts/reportingstatus.html
+++ b/_layouts/reportingstatus.html
@@ -1,3 +1,4 @@
+{% include multilingual.html %}
 {% include head.html %}
 {% include header.html %}
 <div id="main-content" class="container reportingstatus" data-url="{{ site.baseurl }}/indicators.json">

--- a/_layouts/search.html
+++ b/_layouts/search.html
@@ -1,3 +1,4 @@
+{% include multilingual.html %}
 {% include head.html %}
 {% include header.html %}
 <div id="main-content" class="container search-results" role="main">


### PR DESCRIPTION
This jumps to the current head of open-sdg to pickup a bug fix to the page title. See open-sdg/open-sdg#64

Both staging and prod use commit 606b3159e2 of open-sdg. We can pick up the next release when that comes along. Given that this is a bug-fix I will push for a 0.3.1 tag.