### PR TITLE
Fix feature branch metadata issue...?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 _site/
 .sass-cache/
-.jekyll-metadata
 .DS_Store
 .Rproj.user
 .Rhistory


### PR DESCRIPTION
Removing jekyll_metadata from .gitignore - this is a similar problem we saw with [Rwanda](https://github.com/sustainabledevelopment-rwanda/sdg-indicators/commit/3b20f34a380257397c672cb117caa845d0ebef24), which prevented updates from displaying. I don't know why this value is generated. https://github.com/ONSdigital/sdg-indicators/issues/2920