### PR TITLE
Set up data-deploy branch (16.9.1 test)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,21 +12,21 @@ baseurl: "/sdg-indicators" # the subpath of your site, e.g. /blog
 url: ""
 data_dir: data
 environment: staging
-remotedatabaseurl: "http://sdg.mango-solutions.com/data/11.6.2"
+remotedatabaseurl: "http://sdg.mango-solutions.com/data/16.9.1"
 
 # permalink: /news/:year/:month/:day/:title.html
 
 jekyll_get_json:
   - data: meta
-    json: 'http://sdg.mango-solutions.com/data/11.6.2/meta/all.json'
+    json: 'http://sdg.mango-solutions.com/data/16.9.1/meta/all.json'
     # cache: true
     # directory: 'remotedata'
   - data: headlines
-    json: 'http://sdg.mango-solutions.com/data/11.6.2/headline/all.json'
+    json: 'http://sdg.mango-solutions.com/data/16.9.1/headline/all.json'
     # cache: true
     # directory: 'remotedata'
   - data: schema
-    json: 'http://sdg.mango-solutions.com/data/11.6.2/meta/schema.json'
+    json: 'http://sdg.mango-solutions.com/data/16.9.1/meta/schema.json'
   - data: translations
     # Pin to version of the translation repo
     json: 'https://open-sdg.github.io/sdg-translations/translations-0.3.2.json'

--- a/_config.yml
+++ b/_config.yml
@@ -12,20 +12,21 @@ baseurl: "/sdg-indicators" # the subpath of your site, e.g. /blog
 url: ""
 data_dir: data
 environment: staging
-remotedatabaseurl: "https://ONSdigital.github.io/sdg-data"
+remotedatabaseurl: "http://sdg.mango-solutions.com/data/11.6.2"
+
 # permalink: /news/:year/:month/:day/:title.html
 
 jekyll_get_json:
   - data: meta
-    json: 'https://ONSdigital.github.io/sdg-data/meta/all.json'
+    json: 'http://sdg.mango-solutions.com/data/11.6.2/meta/all.json'
     # cache: true
     # directory: 'remotedata'
   - data: headlines
-    json: 'https://ONSdigital.github.io/sdg-data/headline/all.json'
+    json: 'http://sdg.mango-solutions.com/data/11.6.2/headline/all.json'
     # cache: true
     # directory: 'remotedata'
   - data: schema
-    json: 'https://ONSdigital.github.io/sdg-data/meta/schema.json'
+    json: 'http://sdg.mango-solutions.com/data/11.6.2/meta/schema.json'
   - data: translations
     # Pin to version of the translation repo
     json: 'https://open-sdg.github.io/sdg-translations/translations-0.3.2.json'


### PR DESCRIPTION
Testing a deploy branch for a specific edit (in this case, [indicator 16.9.1](https://github.com/ONSdigital/sdg-data/pull/607)). In future, the Data team will use this approach to stage changes and share them with topic experts.

The URL format in _config.yml is http://sdg.mango-solutions.com/data/[BRANCH].

**Note**: I am not sure this will work with a branch containing dots - let's see.
**Note 2**: Correct - branches containing dots will not pass the checks: https://github.com/ONSdigital/sdg-indicators/commit/bc409d21c5d87b2fdfb73c583ff01a3c7d832109