### PR TITLE
Map features (see description)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -119,15 +119,15 @@ map_options:
     id: mapbox.light
     accessToken: pk.eyJ1IjoiYnJvY2tmYW5uaW5nMSIsImEiOiJjaXplbmgzczgyMmRtMnZxbzlmbGJmdW9pIn0.LU-BYMX69uu3eGgk0Imibg
     attribution: <a href="https://www.mapbox.com">Mapbox</a> | <a href="http://geoportal.statistics.gov.uk/">ONS</a>
-  minZoom: 4
+  minZoom: 6
 map_layers:
   #Country
-  - min_zoom: 4
-    max_zoom: 10
-    serviceUrl: https://geoportal1-ons.opendata.arcgis.com/datasets/c362832ce5d14728a6fb2b079525be0b_4.geojson
-    nameProperty: ctry17nm
-    idProperty: ctry17cd
-    staticBorders: true
+  #- min_zoom: 5
+    #max_zoom: 10
+    #serviceUrl: https://geoportal1-ons.opendata.arcgis.com/datasets/c362832ce5d14728a6fb2b079525be0b_4.geojson
+    #nameProperty: ctry17nm
+    #idProperty: ctry17cd
+    #staticBorders: true
     # link: https://hub.arcgis.com/datasets/c362832ce5d14728a6fb2b079525be0b_4/data
   #Region
   - min_zoom: 6

--- a/_config.yml
+++ b/_config.yml
@@ -153,6 +153,3 @@ map_layers:
     #idProperty: cty18cd
     # link: https://hub.arcgis.com/datasets/b7507e654334481e8e0787f42c9028c1_3
     
-    
-    
-    


### PR DESCRIPTION
Country boundaries added to open-sdg map, and zooming overlaps enabled.
Disabling them for now, but we have them on backup now.
To revert, set minZoom to 5 and uncomment lines 125-30.