### PR TITLE
Map features (see description)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -118,14 +118,35 @@ map_options:
     attribution: <a href="https://www.mapbox.com">Mapbox</a> | <a href="http://geoportal.statistics.gov.uk/">ONS</a>
   minZoom: 6
 map_layers:
-  - min_zoom: 0
-    max_zoom: 6
-    serviceUrl: https://opendata.arcgis.com/datasets/4fcca2a47fed4bfaa1793015a18537ac_4.geojson
+  #Country
+  #- min_zoom: 5
+    #max_zoom: 10
+    #serviceUrl: https://geoportal1-ons.opendata.arcgis.com/datasets/c362832ce5d14728a6fb2b079525be0b_4.geojson
+    #nameProperty: ctry17nm
+    #idProperty: ctry17cd
+    #staticBorders: true
+    # link: https://hub.arcgis.com/datasets/c362832ce5d14728a6fb2b079525be0b_4/data
+  #Region
+  - min_zoom: 6
+    max_zoom: 10
+    serviceUrl: https://geoportal1-ons.opendata.arcgis.com/datasets/4fcca2a47fed4bfaa1793015a18537ac_4.geojson
     nameProperty: rgn17nm
     idProperty: rgn17cd
     staticBorders: true
+    # link: https://hub.arcgis.com/datasets/4fcca2a47fed4bfaa1793015a18537ac_4
+  #Local Authority
   - min_zoom: 7
-    max_zoom: 20
+    max_zoom: 10
     serviceUrl: https://geoportal1-ons.opendata.arcgis.com/datasets/686603e943f948acaa13fb5d2b0f1275_4.geojson
     nameProperty: lad16nm
     idProperty: lad16cd
+    staticBorders: false
+    # link: https://hub.arcgis.com/datasets/686603e943f948acaa13fb5d2b0f1275_4
+  #County
+  #- min_zoom: 8
+    #max_zoom: 9
+    #serviceUrl: https://geoportal1-ons.opendata.arcgis.com/datasets/b7507e654334481e8e0787f42c9028c1_3.geojson
+    #nameProperty: cty18nm
+    #idProperty: cty18cd
+    # link: https://hub.arcgis.com/datasets/b7507e654334481e8e0787f42c9028c1_3
+    


### PR DESCRIPTION
Country boundaries added to open-sdg map, and zooming overlaps enabled.
Disabling them for now, but we have them on backup now.
To revert, set minZoom to 5 and uncomment lines 125-30.