### PR TITLE
Remove polyfill.html

### DIFF
--- a/_layouts/indicator.html
+++ b/_layouts/indicator.html
@@ -5,7 +5,6 @@
 {% include components/fields-template.html %}
 {% include components/units-template.html %}
 {% include multilingual-js.html key="indicator" %}
-{% include polyfill.html %}
 
 <div class="heading indicator goal-{{ goal_number }}">
   <div class="container">


### PR DESCRIPTION
Removing `{% include polyfill.html %}` as this didn't work as expected.
The file is still stored in [_includes](https://github.com/ONSdigital/sdg-indicators/blob/develop/_includes/polyfill.html)