### PR TITLE
Change text colours in reporting status page

### DIFF
--- a/assets/css/default.scss
+++ b/assets/css/default.scss
@@ -1307,6 +1307,11 @@ h5 + .btn-download {
         width: 40px;
         text-align: center;
       }
+
+      .status.danger,
+      .status.notstarted{
+        color: white;
+      }
     }
   }
   .value {


### PR DESCRIPTION
Updated `default.scss` to show white text for `.status.danger` and `status.notstarted`.