### PR TITLE
Accessibility updates for mobile top level menu

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -66,7 +66,9 @@
   function setAccessibilityLabels(){
     if(topLevelMenuToggle.classList.contains("active")){
       topLevelMenuToggle.setAttribute("aria-expanded", "true");
-      document.querySelector("#menu .nav-link:first-child").focus();
+      var firstMenuElement = document.querySelector("#menu .nav-link:first-child a");
+      firstMenuElement.focus();
+      console.log(firstMenuElement);
     }
     else{
       console.log("Menu is closed");

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -65,6 +65,7 @@
 
   function setAccessibilityLabels(){
     if(topLevelMenuToggle.classList.contains("active")){
+      console.log("Menu is opened");
       topLevelMenuToggle.setAttribute("aria-expanded", "true");
       var firstMenuElement = document.querySelector("#menu .nav-link:first-child a");
       firstMenuElement.focus();

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -22,12 +22,11 @@
     <nav class="navbar navbar-default" id="main-nav">
 
       <ul class="top-level">
-        <li id="menuToggle">
+        <li id="menuToggle"
+            aria-label="Menu toggle. Click to expand or collapse the menu."
+            aria-haspopup="true"
+            aria-expanded="false">
           <span data-target="menu" tabindex="0"
-          
-          aria-label="Menu toggle. Click to expand or collapse the menu."
-          aria-haspopup="true"
-          aria-expanded="false"
           role="navigation">{{ t.menu.menu }}</span>
         </li>
         <li><span data-target="search">{{ t.search.search }}</span></li>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -60,12 +60,13 @@
   
   topLevelMenuToggle.addEventListener("click", function(){
     setAccessibilityLabels();
+    document.querySelector("#menu .nav-link:first-child a").focus();
   });
 
   function setAccessibilityLabels(){
     if(topLevelMenuToggle.classList.contains("active")){
       topLevelMenuToggle.setAttribute("aria-expanded", "true");
-      document.querySelector("#menu .nav-link:first-child a").focus();
+      
     }
     else{
       console.log("Menu is closed");

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -22,12 +22,13 @@
     <nav class="navbar navbar-default" id="main-nav">
 
       <ul class="top-level">
-        <li id="menuToggle"
+        <li>
+          <span data-target="menu"
+          id="menuToggle"
           aria-label="Menu. Click to expand or collapse the menu."
           aria-haspopup="true"
           aria-expanded="false"
-          role="navigation">
-          <span data-target="menu">{{ t.menu.menu }}</span>
+          role="navigation">{{ t.menu.menu }}</span>
         </li>
         <li><span data-target="search">{{ t.search.search }}</span></li>
       </ul>
@@ -67,7 +68,7 @@
       document.querySelector("#menu .nav-link:first-child").focus();
     }
     else{
-      topLevelMenuToggle.setAttribute("aria-expanded", "false");
+      console.log("Menu is closed");
     }
   }
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -22,9 +22,9 @@
     <nav class="navbar navbar-default" id="main-nav">
 
       <ul class="top-level">
-        <li>
+        <li id="menuToggle">
           <span data-target="menu"
-          id="menuToggle"
+          
           aria-label="Menu. Click to expand or collapse the menu."
           aria-haspopup="true"
           aria-expanded="false"
@@ -56,7 +56,7 @@
 </header>
 
 <script>
-  this.topLevelMenuToggle = document.querySelector(".top-level #menuToggle");
+  this.topLevelMenuToggle = document.querySelector("#menuToggle");
   
   topLevelMenuToggle.addEventListener("click", function(){
     setAccessibilityLabels();

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -60,13 +60,13 @@
   
   topLevelMenuToggle.addEventListener("click", function(){
     setAccessibilityLabels();
-    document.querySelector("#menu .nav-link:first-child a").focus();
+    
   });
 
   function setAccessibilityLabels(){
     if(topLevelMenuToggle.classList.contains("active")){
       topLevelMenuToggle.setAttribute("aria-expanded", "true");
-      
+      document.querySelector("#menu .nav-link:first-child a").focus();
     }
     else{
       console.log("Menu is closed");

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -67,7 +67,7 @@
       document.querySelector("#menu .nav-link:first-child").focus();
     }
     else{
-      console.log("Menu is closed");
+      topLevelMenuToggle.setAttribute("aria-expanded", "false");
     }
   }
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -22,8 +22,8 @@
     <nav class="navbar navbar-default" id="main-nav">
 
       <ul class="top-level">
-        <li id="menuToggle">
-          <span data-target="menu"
+        <li>
+          <span data-target="menu" id="menuToggle"
           
           aria-label="Menu toggle. Click to expand or collapse the menu."
           aria-haspopup="true"

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -65,7 +65,7 @@
   function setAccessibilityLabels(){
     if(topLevelMenuToggle.classList.contains("active")){
       topLevelMenuToggle.setAttribute("aria-expanded", "true");
-      document.querySelector("#menu .nav-link:first-child").focus();
+      document.querySelector("#menu .nav-link:first-child a").focus();
     }
     else{
       console.log("Menu is closed");

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -22,7 +22,13 @@
     <nav class="navbar navbar-default" id="main-nav">
 
       <ul class="top-level">
-        <li><span data-target="menu">{{ t.menu.menu }}</span></li>
+        <li id="menuToggle"
+          aria-label="Menu. Click to expand or collapse the menu."
+          aria-haspopup="true"
+          aria-expanded="false"
+          role="navigation">
+          <span data-target="menu">{{ t.menu.menu }}</span>
+        </li>
         <li><span data-target="search">{{ t.search.search }}</span></li>
       </ul>
 
@@ -47,3 +53,22 @@
   </div>
 
 </header>
+
+<script>
+  this.topLevelMenuToggle = document.querySelector(".top-level #menuToggle");
+  this.topLevelMenu = document.querySelector(".top-level #menu");
+  
+  topLevelMenuToggle.addEventListener("click", function(){
+    setAccessibilityLabels();
+  });
+
+  function setAccessibilityLabels(){
+    if(topLevelMenuToggle.classList.contains("active")){
+      console.log("Menu has been expanded");
+    }
+    else{
+      console.log("Menu is closed");
+    }
+  }
+
+</script>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -22,8 +22,8 @@
     <nav class="navbar navbar-default" id="main-nav">
 
       <ul class="top-level">
-        <li>
-          <span data-target="menu" id="menuToggle" tabindex="0"
+        <li id="menuToggle">
+          <span data-target="menu" tabindex="0"
           
           aria-label="Menu toggle. Click to expand or collapse the menu."
           aria-haspopup="true"

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -22,13 +22,12 @@
     <nav class="navbar navbar-default" id="main-nav">
 
       <ul class="top-level">
-        <li id="menuToggle">
-          <span data-target="menu"
-          
-          aria-label="Menu. Click to expand or collapse the menu."
+        <li id="menuToggle"
+          aria-label="Menu toggle. Click to expand or collapse the menu."
           aria-haspopup="true"
           aria-expanded="false"
-          role="navigation">{{ t.menu.menu }}</span>
+          role="navigation">
+          <span data-target="menu">{{ t.menu.menu }}</span>
         </li>
         <li><span data-target="search">{{ t.search.search }}</span></li>
       </ul>
@@ -65,11 +64,9 @@
 
   function setAccessibilityLabels(){
     if(topLevelMenuToggle.classList.contains("active")){
-      console.log("Menu is opened");
       topLevelMenuToggle.setAttribute("aria-expanded", "true");
       var firstMenuElement = document.querySelector("#menu .nav-link:first-child a");
       firstMenuElement.focus();
-      console.log(firstMenuElement);
     }
     else{
       console.log("Menu is closed");

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -56,7 +56,6 @@
 
 <script>
   this.topLevelMenuToggle = document.querySelector(".top-level #menuToggle");
-  this.topLevelMenu = document.querySelector(".top-level #menu");
   
   topLevelMenuToggle.addEventListener("click", function(){
     setAccessibilityLabels();
@@ -64,7 +63,8 @@
 
   function setAccessibilityLabels(){
     if(topLevelMenuToggle.classList.contains("active")){
-      console.log("Menu has been expanded");
+      topLevelMenuToggle.setAttribute("aria-expanded", "true");
+      document.querySelector("#menu .nav-link:first-child").focus();
     }
     else{
       console.log("Menu is closed");

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -22,12 +22,13 @@
     <nav class="navbar navbar-default" id="main-nav">
 
       <ul class="top-level">
-        <li id="menuToggle"
+        <li id="menuToggle">
+          <span data-target="menu"
+          
           aria-label="Menu toggle. Click to expand or collapse the menu."
           aria-haspopup="true"
           aria-expanded="false"
-          role="navigation">
-          <span data-target="menu">{{ t.menu.menu }}</span>
+          role="navigation">{{ t.menu.menu }}</span>
         </li>
         <li><span data-target="search">{{ t.search.search }}</span></li>
       </ul>
@@ -58,18 +59,29 @@
   this.topLevelMenuToggle = document.querySelector("#menuToggle");
   
   topLevelMenuToggle.addEventListener("click", function(){
-    setAccessibilityLabels();
-    
+    setTopLevelMenuAccessibilityActions();
   });
 
-  function setAccessibilityLabels(){
-    if(topLevelMenuToggle.classList.contains("active")){
-      topLevelMenuToggle.setAttribute("aria-expanded", "true");
-      var firstMenuElement = document.querySelector("#menu .nav-link:first-child a");
-      firstMenuElement.focus();
+  function setTopLevelMenuAccessibilityActions(){
+    if(topLevelMenuIsOpen()){
+      setAriaExpandedStatus(true);
+      focusOnFirstMenuElement();
     }
     else{
-      console.log("Menu is closed");
+      setAriaExpandedStatus(false);
+    }
+
+    function topLevelMenuIsOpen(){
+      return topLevelMenuToggle.classList.contains("active");
+    }
+
+    function setAriaExpandedStatus(expandedStatus){
+      topLevelMenuToggle.setAttribute("aria-expanded", expandedStatus.toString());
+    }
+
+    function focusOnFirstMenuElement(){
+      var firstMenuElement = document.querySelector("#menu .nav-link:first-child a");
+      firstMenuElement.focus();
     }
   }
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -66,7 +66,7 @@
   function setAccessibilityLabels(){
     if(topLevelMenuToggle.classList.contains("active")){
       topLevelMenuToggle.setAttribute("aria-expanded", "true");
-      document.querySelector("#menu .nav-link:first-child a").focus();
+      document.querySelector("#menu .nav-link:first-child").focus();
     }
     else{
       console.log("Menu is closed");

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -23,7 +23,7 @@
 
       <ul class="top-level">
         <li>
-          <span data-target="menu" id="menuToggle"
+          <span data-target="menu" id="menuToggle" tabindex="0"
           
           aria-label="Menu toggle. Click to expand or collapse the menu."
           aria-haspopup="true"

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -80,8 +80,12 @@
     }
 
     function focusOnFirstMenuElement(){
-      var firstMenuElement = document.querySelector("#menu .nav-link:first-child a");
+      var firstMenuElement = getFirstMenuElement();
       firstMenuElement.focus();
+    }
+
+    function getFirstMenuElement(){
+      return document.querySelector("#menu .nav-link:first-child a");
     }
   }
 


### PR DESCRIPTION
I've made some updates to improve accessibility of the top level mobile menu for screen readers:

* When the screen readers is focused on the `Menu` link on mobile, the reader reads it as "Menu toggle. Click to expand or collapse the menu". 

* The link now has `aria-expanded` and `aria-haspopup` attributes that help the reader know this is an expandable menu

* When the user clicks on the Menu, the focus switches automatically to the first element in the menu ("Goals"). This will make it easier to navigate the menu from a screen reader.

I've tested these changes on VoiceOver for Safari on iOS.

Branch test: https://sdg.mango-solutions.com/mobile-menu-a11y-2/