### PR TITLE
[Accessibility] Checkbox screen reader fix

### DIFF
--- a/_includes/assets/js/indicatorView.js
+++ b/_includes/assets/js/indicatorView.js
@@ -635,6 +635,6 @@ var indicatorView = function (model, options) {
     };
     fieldGroupElement.find('label')
     .sort(sortLabels)
-    .appendTo(fieldGroupElement.find('.variable-options'));
+    .appendTo(fieldGroupElement.find('#indicatorData .variable-options'));
   }
 };


### PR DESCRIPTION
Disaggregation checkboxes were losing focus due to a weird quirk of `jQuery`'s `.appendTo()` function. I think this should fix the issue. Screen readers should now also announce when the checkboxes are being ticked or unticked.

Test URL: https://sdg.mango-solutions.com/a11y-checkbox-focus-fix/