### PR TITLE
[Accessibility] Add aria-expanded label updating to disaggregations

### DIFF
--- a/_includes/assets/js/indicatorView.js
+++ b/_includes/assets/js/indicatorView.js
@@ -216,6 +216,10 @@ var indicatorView = function (model, options) {
     var optionsVisible = options.is(':visible');
     $(options)[optionsVisible ? 'hide' : 'show']();
 
+    var optionsVisibleAfterClick = options.is(':visible');
+    var currentSelector = e.target;
+    currentSelector.setAttribute("aria-expanded", optionsVisibleAfterClick ? "true" : "false");
+    
     e.stopPropagation();
   });
 


### PR DESCRIPTION
The `aria-expanded` label updates when a disaggregation is expanded or collapsed so the screen reader notifies the user.