### PR TITLE
Run Pa11y tests on each pull request using Github Actions

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -35,5 +35,4 @@ jobs:
         pagePath="reporting-status" ./scripts/accessibility-test/run_tests.sh
         pagePath="faq" ./scripts/accessibility-test/run_tests.sh
         pagePath="updates" ./scripts/accessibility-test/run_tests.sh
-        pagePath="updates" ./scripts/accessibility-test/run_tests.sh
         pagePath="accessibility-statement" ./scripts/accessibility-test/run_tests.sh

--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -1,23 +1,21 @@
-# This is a basic workflow to help you get started with Actions
-
-name: CI
+name: Accessibility
 
 on: [pull_request]
 
 jobs:
-  build:
+  accessibility-tests:
     runs-on: ubuntu-latest
 
     steps:
 
     - uses: actions/checkout@v2
       
-    - name: Setup Ruby, JRuby and TruffleRuby
+    - name: Setup Ruby
       uses: ruby/setup-ruby@v1.38.0
       with:
         ruby-version: 2.7
         
-    - name: Setup Node.js environment
+    - name: Setup NodeJS
       uses: actions/setup-node@v1.4.2
       
     - name: Build site

--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -34,4 +34,4 @@ jobs:
         pa11y ./_site/1/index.html
         pa11y ./_site/reporting-status/index.html
         pa11y ./_site/about/index.html
-        
+        pa11y ./_site/1-1-1/index.html

--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -35,3 +35,8 @@ jobs:
         pagePath="1" ./scripts/accessibility-test/run_tests.sh
         pagePath="about" ./scripts/accessibility-test/run_tests.sh
         pagePath="reporting-status" ./scripts/accessibility-test/run_tests.sh
+        pagePath="publications" ./scripts/accessibility-test/run_tests.sh
+        pagePath="faq" ./scripts/accessibility-test/run_tests.sh
+        pagePath="updates" ./scripts/accessibility-test/run_tests.sh
+        pagePath="updates" ./scripts/accessibility-test/run_tests.sh
+        pagePath="accessibility-statement" ./scripts/accessibility-test/run_tests.sh

--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -31,7 +31,5 @@ jobs:
     - name: Run accessibility tests
       run: |
         pa11y ./_site/index.html
-        pa11y ./_site/1/index.html
-        pa11y ./_site/reporting-status/index.html
-        pa11y ./_site/about/index.html
-        pa11y ./_site/1-1-1/index.html
+        pa11y --config ./scripts/config/mobile.json ./_site/index.html
+        pa11y --config ./scripts/config/high-contrast.json ./_site/index.html

--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -16,11 +16,22 @@ jobs:
       uses: ruby/setup-ruby@v1.38.0
       with:
         ruby-version: 2.7
+        
+    - name: Setup Node.js environment
+      uses: actions/setup-node@v1.4.2
       
     - name: Build site
       run: |
         gem install jekyll bundler
         bundle install && bundle exec jekyll build
 
-    - name: List site files
-      run: ls _site
+    - name: Install Pa11y
+      run: npm install -g pa11y
+
+    - name: Run accessibility tests
+      run: |
+        pa11y ./_site/index.html
+        pa11y ./_site/1/index.html
+        pa11y ./_site/reporting-status/index.html
+        pa11y ./_site/about/index.html
+        

--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -30,6 +30,8 @@ jobs:
 
     - name: Run accessibility tests
       run: |
-        pa11y ./_site/index.html
-        pa11y --config ./scripts/config/mobile.json ./_site/index.html
-        pa11y --config ./scripts/config/high-contrast.json ./_site/index.html
+        chmod +x ./scripts/accessibility-test/run_tests.sh
+        ./scripts/accessibility-test/run_tests.sh
+        pagePath="1" ./scripts/accessibility-test/run_tests.sh
+        pagePath="about" ./scripts/accessibility-test/run_tests.sh
+        pagePath="reporting-status" ./scripts/accessibility-test/run_tests.sh

--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -35,7 +35,6 @@ jobs:
         pagePath="1" ./scripts/accessibility-test/run_tests.sh
         pagePath="about" ./scripts/accessibility-test/run_tests.sh
         pagePath="reporting-status" ./scripts/accessibility-test/run_tests.sh
-        pagePath="publications" ./scripts/accessibility-test/run_tests.sh
         pagePath="faq" ./scripts/accessibility-test/run_tests.sh
         pagePath="updates" ./scripts/accessibility-test/run_tests.sh
         pagePath="updates" ./scripts/accessibility-test/run_tests.sh

--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -1,0 +1,24 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - uses: actions/checkout@v2
+      
+    - name: Setup Ruby, JRuby and TruffleRuby
+      uses: ruby/setup-ruby@v1.38.0
+      
+    - name: Build site
+      run: |
+        gem install jekyll bundler
+        bundle install && bundle exec jekyll build
+
+    - name: List site files
+      run: ls _site

--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -14,6 +14,8 @@ jobs:
       
     - name: Setup Ruby, JRuby and TruffleRuby
       uses: ruby/setup-ruby@v1.38.0
+      with:
+        ruby-version: 2.7
       
     - name: Build site
       run: |

--- a/scripts/accessibility-test/config/high-contrast.json
+++ b/scripts/accessibility-test/config/high-contrast.json
@@ -1,0 +1,6 @@
+{
+    "viewport": {
+        "width": 320,
+        "height": 480
+    }
+}

--- a/scripts/accessibility-test/run_tests.sh
+++ b/scripts/accessibility-test/run_tests.sh
@@ -1,0 +1,3 @@
+pa11y ./_site/$pagePath/index.html
+pa11y --config ./scripts/config/mobile.json ./_site/$pagePath/index.html
+pa11y --config ./scripts/config/high-contrast.json ./_site/$pagePath/index.html

--- a/scripts/accessibility-test/run_tests.sh
+++ b/scripts/accessibility-test/run_tests.sh
@@ -1,3 +1,6 @@
+echo "Desktop test"
 pa11y ./_site/$pagePath/index.html
+echo "Mobile test"
 pa11y --config ./scripts/config/mobile.json ./_site/$pagePath/index.html
+echo "High contrast test"
 pa11y --config ./scripts/config/high-contrast.json ./_site/$pagePath/index.html


### PR DESCRIPTION
This change uses Github Actions to run accessibility tests using Pa11y. This is a response to [this Trello card](https://trello.com/c/CviKnpSQ).

### What happens?

During the action:

1. The repo gets checked out at the specific branch
2. Ruby and NodeJS get installed
3. The Jekyll website gets built
4. Pa11y gets installed via `npm`
5. Pa11y tests are run on a selection of websites and configurations

### What pages are being tested?

We have previously made a list of pages with special features in order to test them for accessibility. As the accessibility issues haven't been fixed, and this pull request is for adding the tests to run and complete, I have omitted some of the pages. For now, these pages get tested for accessibility:

* Home
* Goal 1
* About
* Reporting status
* FAQ
* Updates
* Accessibility statement