### PR TITLE
Overwrite indicator-content.html

### DIFF
--- a/_includes/components/indicator/indicator-content.html
+++ b/_includes/components/indicator/indicator-content.html
@@ -1,0 +1,21 @@
+{% assign indicator_page_content_raw = page.indicator.page_content | strip %}
+{% if indicator_page_content_raw != '' %}
+<div class="row" id="page-content">
+  <div class="col-xs-12">
+    {{ indicator_page_content_raw | t | markdownify }}
+    {% if page.indicator.reporting_status == 'complete' and page.indicator.data_non_statistical == false %}
+      <br>Select the following link to download this indicator data in an accessible format:<br><a href="{{ page.remote_data_prefix }}/data/{{ page.indicator.number | replace: ".", "-" }}.csv">{{ page.indicator.indicator_available }} (CSV {{ page.indicator.csv_size }})</a>
+    {% endif %}
+  </div>
+</div>
+{% else %}
+<div class="row" id="page-content">
+  <div class="col-xs-12">
+    {% if page.indicator.reporting_status == 'notstarted' %}
+      <p><b>Exploring data sources</b><br /><br />
+      We have not yet identified suitable data sources for this indicator.<br /><br />
+      The Sustainable Development Goals are a collaborative project, if you have any feedback or suggestions for data please contact us at <a href="mailto:SustainableDevelopment@ons.gov.uk">SustainableDevelopment@ons.gov.uk</a></p>
+    {% endif %}
+  </div>
+</div>
+{% endif %}


### PR DESCRIPTION
Automatically generate CSV download text and link in catch-all text section when indicator is reported and non-statistical. When indicator is not reported, generate some text.