### PR TITLE
Update site_config.yml

### DIFF
--- a/_data/site_config.yml
+++ b/_data/site_config.yml
@@ -331,9 +331,7 @@ frontpage_cards:
 
       [Implementing the Sustainable Development
       Goals](https://www.gov.uk/government/publications/implementing-the-sustainable-development-goals/implementing-the-sustainable-development-goals--2)
-      
      
-      <br/><br/>
 
       <a href="./about/#more-resources" aria-label="More resources">More
       resources...</a>

--- a/_data/site_config.yml
+++ b/_data/site_config.yml
@@ -333,7 +333,10 @@ frontpage_cards:
       Goals](https://www.gov.uk/government/publications/implementing-the-sustainable-development-goals/implementing-the-sustainable-development-goals--2)
       
      
-      [More resources...](https://sdgdata.gov.uk/about/#useful-resources)
+      <br/><br/>
+
+      <a href="./about/#more-resources" aria-label="More resources">More
+      resources...</a>
     include: ''
     button_label: ''
     button_link: ''


### PR DESCRIPTION
@Tom-McNulty when doing the testing i realised that the link on the home page was still going to 'useful resources' rather than what i updated it to - 'more resources'. Also i noticed the 'more publications' link on the home page went to an in house page rather than just linking the end page like we had done, so i copied that format! check it out in the files changed section here to see :D  

feature branch here - http://uk-sdg-feature-branches.s3-website.eu-west-2.amazonaws.com/feature-site-more-resources/